### PR TITLE
Configurable git clone depth

### DIFF
--- a/pkg/git/git_repo.go
+++ b/pkg/git/git_repo.go
@@ -3,6 +3,8 @@ package git
 import (
 	"fmt"
 	"io/fs"
+	"os"
+	"strconv"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -120,4 +122,16 @@ func WalkRepo(s string, d fs.DirEntry, err error) error {
 		println(s)
 	}
 	return nil
+}
+
+// GetCloneDepth reads the provided env var and returns an int to be used as git clone depth. Default is 0.
+func GetCloneDepth(envVar string) int {
+	val := os.Getenv(envVar)
+	if val != "" {
+		depth, err := strconv.Atoi(val)
+		if err == nil {
+			return depth
+		}
+	}
+	return 0
 }

--- a/pkg/git/git_repo_test.go
+++ b/pkg/git/git_repo_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,4 +92,21 @@ func TestGetModifiedFileNamesBetweenCommitsNoResults(t *testing.T) {
 	modifiedFiles, err := client.GetModifiedFileNamesBetweenCommits(commonCommit, "master")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, len(modifiedFiles), 0, "expected no files modified between master and test")
+}
+
+func TestGitCloneDepth(t *testing.T) {
+	testVar := "git-clone-test"
+	defer os.Unsetenv(testVar)
+	t.Run("no value", func(t *testing.T) {
+		os.Unsetenv(testVar)
+		assert.Equal(t, 0, GetCloneDepth(testVar))
+	})
+	t.Run("500 depth", func(t *testing.T) {
+		os.Setenv(testVar, "500")
+		assert.Equal(t, 500, GetCloneDepth(testVar))
+	})
+	t.Run("invalid value", func(t *testing.T) {
+		os.Setenv(testVar, "somestuff")
+		assert.Equal(t, 0, GetCloneDepth(testVar))
+	})
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -119,6 +119,8 @@ func (c *Client) GetMergeRequestModifiedFiles(prID int, fullName string) ([]stri
 	return []string{}, nil
 }
 
+const GITHUB_CLONE_DEPTH_ENV = "TFBUDDY_GITHUB_CLONE_DEPTH"
+
 func (c *Client) CloneMergeRequest(project string, mr vcs.MR, dest string) (vcs.GitRepo, error) {
 	parts, err := splitFullName(project)
 	if err != nil {
@@ -140,13 +142,13 @@ func (c *Client) CloneMergeRequest(project string, mr vcs.MR, dest string) (vcs.
 	if log.Trace().Enabled() {
 		progress = os.Stdout
 	}
-
+	cloneDepth := zgit.GetCloneDepth(GITHUB_CLONE_DEPTH_ENV)
 	gitRepo, err := git.PlainClone(dest, false, &git.CloneOptions{
 		Auth:          auth,
 		URL:           *repo.CloneURL,
 		ReferenceName: ref,
 		SingleBranch:  true,
-		Depth:         10,
+		Depth:         cloneDepth,
 	})
 
 	if err != nil && err != git.ErrRepositoryAlreadyExists {
@@ -158,8 +160,8 @@ func (c *Client) CloneMergeRequest(project string, mr vcs.MR, dest string) (vcs.
 		//RemoteName:        "",
 		ReferenceName: ref,
 		//SingleBranch:      false,
-		//Depth:             0,
-		Auth: auth,
+		Depth: cloneDepth,
+		Auth:  auth,
 		//RecurseSubmodules: 0,
 		Progress: progress,
 		Force:    false,

--- a/pkg/github/hooks/stream_worker.go
+++ b/pkg/github/hooks/stream_worker.go
@@ -96,11 +96,9 @@ func (h *GithubHooksHandler) processIssueCommentEvent(msg *GithubIssueCommentEve
 	}
 	executedWorkspaces, tfError := trigger.TriggerTFCEvents()
 	if tfError == nil && len(executedWorkspaces.Errored) > 0 {
-		failedMsg := ""
 		for _, failedWS := range executedWorkspaces.Errored {
-			failedMsg += fmt.Sprintf("%s could not be run because: %s\n", failedWS.Name, failedWS.Error)
+			h.postPullRequestComment(event, fmt.Sprintf(":no_entry: %s could not be run because: %s", failedWS.Name, failedWS.Error))
 		}
-		h.postPullRequestComment(event, fmt.Sprintf(":no_entry: %s", failedMsg))
 		return nil
 	}
 	return tfError

--- a/pkg/gitlab/git_actions.go
+++ b/pkg/gitlab/git_actions.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/errgo.v2/fmt/errors"
 )
 
-const GIT_CLONE_DEPTH_ENV = "TFBUDDY_GITLAB_CLONE_DEPTH"
+const GITLAB_CLONE_DEPTH_ENV = "TFBUDDY_GITLAB_CLONE_DEPTH"
 
 // CloneMergeRequest performs a git clone of the target Gitlab project & merge request branch to the `dest` path.
 func (c *GitlabClient) CloneMergeRequest(project string, mr vcs.MR, dest string) (vcs.GitRepo, error) {
@@ -38,7 +38,7 @@ func (c *GitlabClient) CloneMergeRequest(project string, mr vcs.MR, dest string)
 	if log.Trace().Enabled() {
 		progress = os.Stdout
 	}
-	cloneDepth := zgit.GetCloneDepth(GIT_CLONE_DEPTH_ENV)
+	cloneDepth := zgit.GetCloneDepth(GITLAB_CLONE_DEPTH_ENV)
 
 	repo, err := git.PlainClone(dest, false, &git.CloneOptions{
 		Auth:          auth,

--- a/pkg/gitlab_hooks/comment_actions.go
+++ b/pkg/gitlab_hooks/comment_actions.go
@@ -83,11 +83,9 @@ func (w *GitlabEventWorker) processNoteEvent(event vcs.MRCommentEvent) (projectN
 	}
 	executedWorkspaces, tfError := trigger.TriggerTFCEvents()
 	if tfError == nil && len(executedWorkspaces.Errored) > 0 {
-		failedMsg := ""
 		for _, failedWS := range executedWorkspaces.Errored {
-			failedMsg += fmt.Sprintf("%s could not be run because: %s\n", failedWS.Name, failedWS.Error)
+			w.postMessageToMergeRequest(event, fmt.Sprintf(":no_entry: %s could not be run because: %s", failedWS.Name, failedWS.Error))
 		}
-		w.postMessageToMergeRequest(event, fmt.Sprintf(":no_entry: %s", failedMsg))
 		return proj, nil
 	}
 	return proj, tfError

--- a/pkg/mocks/helpers.go
+++ b/pkg/mocks/helpers.go
@@ -127,6 +127,7 @@ type TestSuite struct {
 	MockTriggerConfig *MockTriggerConfig
 	MockApiClient     *MockApiClient
 	MockStreamClient  *MockStreamClient
+	MockProject       *MockProject
 	MetaData          *TestMetaData
 }
 type TestOverrides struct {
@@ -171,10 +172,12 @@ func (ts *TestSuite) InitTestSuite() {
 	ts.MockGitClient.EXPECT().CreateMergeRequestDiscussion(ts.MetaData.MRIID, ts.MetaData.ProjectNameNS, &RegexMatcher{regex: regexp.MustCompile("Starting TFC apply for Workspace: `([A-z\\-]){1,}/([A-z\\-]){1,}`.")}).Return(ts.MockGitDisc, nil).AnyTimes()
 
 	ts.MockTriggerConfig.EXPECT().GetAction().Return(tfc_trigger.ApplyAction).AnyTimes()
+	ts.MockTriggerConfig.EXPECT().SetAction(gomock.Any()).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().GetMergeRequestIID().Return(ts.MetaData.MRIID).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().GetProjectNameWithNamespace().Return(ts.MetaData.ProjectNameNS).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().GetBranch().Return(ts.MetaData.SourceBranch).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().GetWorkspace().Return("").AnyTimes()
+	ts.MockTriggerConfig.EXPECT().SetWorkspace(gomock.Any()).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().SetMergeRequestDiscussionID(gomock.Any()).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().SetMergeRequestRootNoteID(gomock.Any()).AnyTimes()
 	ts.MockTriggerConfig.EXPECT().GetCommitSHA().Return("abcd12233").AnyTimes()
@@ -187,6 +190,8 @@ func (ts *TestSuite) InitTestSuite() {
 	ts.MockApiClient.EXPECT().AddTags(gomock.Any(), gomock.Any(), "tfbuddylock", "101").AnyTimes()
 
 	ts.MockStreamClient.EXPECT().AddRunMeta(gomock.Any()).AnyTimes()
+
+	ts.MockProject.EXPECT().GetPathWithNamespace().Return(ts.MetaData.ProjectNameNS).AnyTimes()
 
 }
 
@@ -226,6 +231,8 @@ func CreateTestSuite(mockCtrl *gomock.Controller, overrides TestOverrides, t *te
 
 	mockStreamClient := NewMockStreamClient(mockCtrl)
 
+	mockProject := NewMockProject(mockCtrl)
+
 	return &TestSuite{
 		MockGitClient:     mockGitClient,
 		MockGitMR:         mockGitMR,
@@ -235,6 +242,7 @@ func CreateTestSuite(mockCtrl *gomock.Controller, overrides TestOverrides, t *te
 		MockTriggerConfig: mockTriggerConfig,
 		MockApiClient:     mockApiClient,
 		MockStreamClient:  mockStreamClient,
+		MockProject:       mockProject,
 		MetaData: &TestMetaData{
 			MRIID:         mrIID,
 			ProjectNameNS: projectNameNS,


### PR DESCRIPTION
[Related issue](https://github.com/zapier/tfbuddy/issues/7)

I also added a warning if we encounter an error when attempting to find modified workspaces between the merge base and target branch. Previously we would error out.

![err](https://cdn.zappy.app/35d7e128141f30473bfb1f1a5656d88b.png)
