### PR TITLE
Prevent Gitlab MR events from being dropped

### DIFF
--- a/pkg/gitlab_hooks/hook_worker.go
+++ b/pkg/gitlab_hooks/hook_worker.go
@@ -38,15 +38,11 @@ func NewGitlabEventWorker(h *GitlabHooksHandler, js nats.JetStreamContext) *Gitl
 }
 
 func (w *GitlabEventWorker) processNoteEventStreamMsg(msg *NoteEventMsg) error {
-
-	w.processNoteEvent(msg)
-
-	return nil
+	_, err := w.processNoteEvent(msg)
+	return err
 }
 
 func (w *GitlabEventWorker) processMREventStreamMsg(msg *MergeRequestEventMsg) error {
-
-	w.processMergeRequestEvent(msg)
-
-	return nil
+	_, err := w.processMergeRequestEvent(msg)
+	return err
 }

--- a/pkg/gitlab_hooks/stream_msgs.go
+++ b/pkg/gitlab_hooks/stream_msgs.go
@@ -82,7 +82,7 @@ type MergeRequestEventMsg struct {
 }
 
 func (e *MergeRequestEventMsg) GetId() string {
-	return fmt.Sprintf("%d", e.payload.ObjectAttributes.ID)
+	return fmt.Sprintf("%d-%s", e.payload.ObjectAttributes.ID, e.payload.ObjectAttributes.Action)
 }
 
 func (e *MergeRequestEventMsg) DecodeEventData(b []byte) error {


### PR DESCRIPTION
We're hitting an edge case where a user resolves all threads on a MR which fires a webhook with an update action. This is usually followed by the user merging in quick succession. This fires a second webhook with a merge action. These both are handled on the HOOKS queue which has a 2min dedup window. We use ObjectAttribute.ID currently for the [Message ID](https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#message-deduplication) which causes the second webhook to be dropped preventing workspace cleanup from occurring. 

I also updated the note/mr process functions to return their errors to prevent a message from being acked if there's a problem. @sl1pm4t Im not sure if this was intentional or not. 