### PR TITLE
Delete old comments whenever we start a new TFC run

### DIFF
--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -169,3 +169,7 @@ var needToApplyFullWorkSpace = `
 
 **Need to Apply Full Workspace Before Merging**
 `
+
+const OLD_RUN_BLOCK = `
+### Previous TFC URLS
+%s`

--- a/pkg/mocks/mock_vcs.go
+++ b/pkg/mocks/mock_vcs.go
@@ -58,6 +58,9 @@ func (m *MockGitClient) CloneMergeRequest(arg0 string, arg1 vcs.MR, arg2 string)
 	return ret0, ret1
 }
 
+func (m *MockGitClient) GetOldRunUrls(mrIID int, project string, rootNoteID int, deleteNotes bool) (string, error) {
+	return "", nil
+}
 // CloneMergeRequest indicates an expected call of CloneMergeRequest.
 func (mr *MockGitClientMockRecorder) CloneMergeRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/pkg/mocks/mock_vcs.go
+++ b/pkg/mocks/mock_vcs.go
@@ -58,7 +58,7 @@ func (m *MockGitClient) CloneMergeRequest(arg0 string, arg1 vcs.MR, arg2 string)
 	return ret0, ret1
 }
 
-func (m *MockGitClient) GetOldRunUrls(mrIID int, project string, rootNoteID int, deleteNotes bool) (string, error) {
+func (m *MockGitClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) (string, error) {
 	return "", nil
 }
 // CloneMergeRequest indicates an expected call of CloneMergeRequest.

--- a/pkg/utils/formatter.go
+++ b/pkg/utils/formatter.go
@@ -2,14 +2,19 @@ package utils
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
 // We format the URL as **RUN URL**: <url> <br> under tfc_status_update.go
 const (
-	URL_RUN_PREFIX        = "**Run URL**: "
-	URL_RUN_SUFFIX        = "<br>"
-	URL_RUN_GROUP_PREFIX  = "<details><summary>Previous TFC URLS</summary>\n"
+	URL_RUN_PREFIX       = "**Run URL**: "
+	URL_RUN_SUFFIX       = "<br>"
+	URL_RUN_GROUP_PREFIX = `<details><summary>
+
+### Previous TFC Urls:
+
+</summary>`
 	URL_RUN_GROUP_SUFFIX  = "</details>"
 	URL_RUN_STATUS_PREFIX = "**Status**: "
 )
@@ -31,6 +36,8 @@ func CaptureSubstring(body string, prefix string, suffix string) string {
 
 // AI generated these, may not be compresphenive
 func FormatStatus(status string) string {
+	status = strings.Trim(status, "`")
+	log.Printf("Status: %s", status)
 	switch status {
 	case "applied":
 		return "✅ Applied"
@@ -52,24 +59,4 @@ func FormatStatus(status string) string {
 		// anything we can't match just preserve with the ticks
 		return fmt.Sprintf("`%s`", status)
 	}
-}
-
-// Try and find the "Run URL:" string in the body and return it
-// If we can't find it, return nothing
-func CaptureRunURLFromBody(body string) string {
-	// First, see if we already have a grouping, which means this has run before
-	startIndex := strings.Index(body, URL_RUN_PREFIX)
-	if startIndex == -1 {
-		// Can't find a URL to pull out, so we'll just return
-		return ""
-	}
-
-	// At this point we've found a starting index, and se tthe appropriate suffix, now to try and pull a URL out
-	subBody := body[startIndex+len(URL_RUN_PREFIX):]
-	endIndex := strings.Index(subBody, URL_RUN_SUFFIX)
-	if endIndex == -1 {
-		return "" // Couldn't determine where to cut
-	}
-
-	return subBody[:endIndex]
 }

--- a/pkg/utils/formatter.go
+++ b/pkg/utils/formatter.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// We format the URL as **RUN URL**: <url> <br> under tfc_status_update.go
+const (
+	URL_RUN_PREFIX        = "**Run URL**: "
+	URL_RUN_SUFFIX        = "<br>"
+	URL_RUN_GROUP_PREFIX  = "<details><summary>Previous TFC URLS</summary>\n"
+	URL_RUN_GROUP_SUFFIX  = "</details>"
+	URL_RUN_STATUS_PREFIX = "**Status**: "
+)
+
+func CaptureSubstring(body string, prefix string, suffix string) string {
+	startIndex := strings.Index(body, prefix)
+	if startIndex == -1 {
+		return ""
+	}
+
+	subBody := body[startIndex+len(prefix):]
+	endIndex := strings.Index(subBody, suffix)
+	if endIndex == -1 {
+		return ""
+	}
+
+	return subBody[:endIndex]
+}
+
+// AI generated these, may not be compresphenive
+func FormatStatus(status string) string {
+	switch status {
+	case "applied":
+		return "✅ Applied"
+	case "planned":
+		return "📝 Planned"
+	case "policy_checked":
+		return "📝 Policy Checked"
+	case "policy_soft_failed":
+		return "📝 Policy Soft Failed"
+	case "errored":
+		return "❌ Errored"
+	case "canceled":
+		return "❌ Canceled"
+	case "discarded":
+		return "❌ Discarded"
+	case "planned_and_finished":
+		return "📝 Planned and Finished"
+	default:
+		// anything we can't match just preserve with the ticks
+		return fmt.Sprintf("`%s`", status)
+	}
+}
+
+// Try and find the "Run URL:" string in the body and return it
+// If we can't find it, return nothing
+func CaptureRunURLFromBody(body string) string {
+	// First, see if we already have a grouping, which means this has run before
+	startIndex := strings.Index(body, URL_RUN_PREFIX)
+	if startIndex == -1 {
+		// Can't find a URL to pull out, so we'll just return
+		return ""
+	}
+
+	// At this point we've found a starting index, and se tthe appropriate suffix, now to try and pull a URL out
+	subBody := body[startIndex+len(URL_RUN_PREFIX):]
+	endIndex := strings.Index(subBody, URL_RUN_SUFFIX)
+	if endIndex == -1 {
+		return "" // Couldn't determine where to cut
+	}
+
+	return subBody[:endIndex]
+}

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -62,7 +62,7 @@ func (c *Client) GetMergeRequestApprovals(id int, project string) (vcs.MRApprove
 }
 
 // Go over all comments on a PR, trying to grab any old TFC run urls and deleting the bodies
-func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int, deleteComment bool) (string, error) {
+func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (string, error) {
 	log.Debug().Msg("pruneComments")
 	projectParts, err := splitFullName(fullName)
 	if err != nil {
@@ -96,7 +96,7 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int, del
 				oldRunBlock = oldRunBlockTest
 			}
 
-			if deleteComment && comment.GetID() != int64(rootCommentID) {
+			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && comment.GetID() != int64(rootCommentID) {
 				log.Debug().Msgf("Deleting comment %d", comment.GetID())
 				_, err := c.client.Issues.DeleteComment(c.ctx, projectParts[0], projectParts[1], comment.GetID())
 				if err != nil {

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -111,7 +111,7 @@ func (c *GitlabClient) GetCommitStatuses(projectID, commitSHA string) []*gogitla
 }
 
 // Crawl the comments on this MR for tfbuddy comments, grab any TFC urls out of them, and delete them.
-func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int, deleteNotes bool) (string, error) {
+func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) (string, error) {
 	log.Debug().Str("projectID", project).Int("mrIID", mrIID).Msg("pruning notes")
 	notes, _, err := c.client.Notes.ListMergeRequestNotes(project, mrIID, &gogitlab.ListMergeRequestNotesOptions{})
 	if err != nil {
@@ -139,7 +139,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int, 
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
 			}
-			if deleteNotes && note.ID != rootNoteID {
+			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && note.ID != rootNoteID {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Msgf("deleting note %d", note.ID)
 				_, err := c.client.Notes.DeleteMergeRequestNote(project, mrIID, note.ID)
 				if err != nil {

--- a/pkg/vcs/gitlab/mr_comment_updater.go
+++ b/pkg/vcs/gitlab/mr_comment_updater.go
@@ -17,9 +17,9 @@ func (p *RunStatusUpdater) postRunStatusComment(run *tfe.Run, rmd runstream.RunM
 
 	var oldUrls string
 	var err error
-	// TODO: Make this configurable behaviour
+
 	if run.Status == tfe.RunErrored || run.Status == tfe.RunCanceled || run.Status == tfe.RunDiscarded || run.Status == tfe.RunPlannedAndFinished {
-		oldUrls, err = p.client.GetOldRunUrls(rmd.GetMRInternalID(), rmd.GetMRProjectNameWithNamespace(), int(rmd.GetRootNoteID()), true)
+		oldUrls, err = p.client.GetOldRunUrls(rmd.GetMRInternalID(), rmd.GetMRProjectNameWithNamespace(), int(rmd.GetRootNoteID()))
 		if err != nil {
 			log.Error().Err(err).Msg("could not retrieve old run urls")
 		}

--- a/pkg/vcs/gitlab/mr_comment_updater.go
+++ b/pkg/vcs/gitlab/mr_comment_updater.go
@@ -15,6 +15,19 @@ func (p *RunStatusUpdater) postRunStatusComment(run *tfe.Run, rmd runstream.RunM
 
 	commentBody, topLevelNoteBody, resolveDiscussion := comment_formatter.FormatRunStatusCommentBody(p.tfc, run, rmd)
 
+	var oldUrls string
+	var err error
+	// TODO: Make this configurable behaviour
+	if run.Status == tfe.RunErrored || run.Status == tfe.RunCanceled || run.Status == tfe.RunDiscarded || run.Status == tfe.RunPlannedAndFinished {
+		oldUrls, err = p.client.GetOldRunUrls(rmd.GetMRInternalID(), rmd.GetMRProjectNameWithNamespace(), int(rmd.GetRootNoteID()), true)
+		if err != nil {
+			log.Error().Err(err).Msg("could not retrieve old run urls")
+		}
+		if oldUrls != "" {
+			topLevelNoteBody = fmt.Sprintf("%s\n%s", oldUrls, topLevelNoteBody)
+		}
+	}
+	//oldURLBlock := utils.CaptureSubstring(, prefix string, suffix string)
 	if _, err := p.client.UpdateMergeRequestDiscussionNote(
 		rmd.GetMRInternalID(),
 		int(rmd.GetRootNoteID()),

--- a/pkg/vcs/interfaces.go
+++ b/pkg/vcs/interfaces.go
@@ -15,7 +15,7 @@ type GitClient interface {
 	AddMergeRequestDiscussionReply(mrIID int, project, discussionID, comment string) (MRNote, error)
 	SetCommitStatus(projectWithNS string, commitSHA string, status CommitStatusOptions) (CommitStatus, error)
 	GetPipelinesForCommit(projectWithNS string, commitSHA string) ([]ProjectPipeline, error)
-	GetOldRunUrls(mrIID int, project string, rootCommentID int, deleteNotes bool) (string, error)
+	GetOldRunUrls(mrIID int, project string, rootCommentID int) (string, error)
 }
 type GitRepo interface {
 	FetchUpstreamBranch(string) error

--- a/pkg/vcs/interfaces.go
+++ b/pkg/vcs/interfaces.go
@@ -15,6 +15,7 @@ type GitClient interface {
 	AddMergeRequestDiscussionReply(mrIID int, project, discussionID, comment string) (MRNote, error)
 	SetCommitStatus(projectWithNS string, commitSHA string, status CommitStatusOptions) (CommitStatus, error)
 	GetPipelinesForCommit(projectWithNS string, commitSHA string) ([]ProjectPipeline, error)
+	GetOldRunUrls(mrIID int, project string, rootCommentID int, deleteNotes bool) (string, error)
 }
 type GitRepo interface {
 	FetchUpstreamBranch(string) error


### PR DESCRIPTION
This PR adds in a deletion/summary feature for Gitlab usage. GitHub usage is a little different, so I haven't implemented it for this, but we could feasibly do it in future.