### PR TITLE
Add support for Terraform 1.5 `import {}` actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v49 v49.0.0
-	github.com/hashicorp/go-tfe v1.16.0
+	github.com/hashicorp/go-tfe v1.30.0
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/jessevdk/go-flags v1.5.0
@@ -27,7 +27,7 @@ require (
 	github.com/sl1pm4t/gongs v0.0.0-20221205005205-6f4e6d147fab
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	github.com/xanzy/go-gitlab v0.77.0
 	github.com/ziflex/lecho/v3 v3.3.0
 	golang.org/x/oauth2 v0.3.0
@@ -51,8 +51,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
-	github.com/hashicorp/go-slug v0.10.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
+	github.com/hashicorp/go-slug v0.11.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d // indirect
@@ -95,7 +95,7 @@ require (
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v49 v49.0.0
 	github.com/hashicorp/go-tfe v1.30.0
-	github.com/hashicorp/terraform-json v0.14.0
+	github.com/hashicorp/terraform-json v0.17.1
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/kr/pretty v0.3.1
@@ -40,6 +40,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudflare/circl v1.3.2 // indirect
@@ -91,7 +92,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
+github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -214,6 +215,8 @@ github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB1
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
+github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQHgyRwf3RkyA=
+github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -382,6 +385,8 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY=
 github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
+github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
+github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/ziflex/lecho/v3 v3.3.0 h1:Z6KnMf0ubJX93W8Np37DBIZalFubYDq0a92hv3S/9CY=
 github.com/ziflex/lecho/v3 v3.3.0/go.mod h1:VyOQDbC51eP3iJ4NdcyQbhmTqUZiapn7zJ3oHknCmXU=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb h1:Vx1Bw/nGUL
 github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -111,6 +113,7 @@ github.com/go-git/go-git/v5 v5.5.2/go.mod h1:BE5hUJ5yaV2YMxhmaP4l6RBQ08kMxKSPD4B
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
@@ -189,10 +192,16 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-slug v0.10.1 h1:05SCRWCBpCxOeP7stQHvMgOz0raCBCekaytu8Rg/RZ4=
 github.com/hashicorp/go-slug v0.10.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
+github.com/hashicorp/go-slug v0.11.1 h1:c6lLdQnlhUWbS5I7hw8SvfymoFuy6EmiFDedy6ir994=
+github.com/hashicorp/go-slug v0.11.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v1.16.0 h1:B4yEfNNHuCiBjXXci+UiE5MsScAM+pfXwDXhBdNmOOg=
 github.com/hashicorp/go-tfe v1.16.0/go.mod h1:77snluBqtTTvMrY0w/mxQA5jlHQ8NT44AqQ8UdrPf0o=
+github.com/hashicorp/go-tfe v1.30.0 h1:vEieLxZ0Xly4+njypVwHH0RcUip7za1p6Pw52iqLOAY=
+github.com/hashicorp/go-tfe v1.30.0/go.mod h1:z0182DGE/63AKUaWblUVBIrt+xdSmsuuXg5AoxGqDF4=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -218,8 +227,11 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -263,6 +275,9 @@ github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HK
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt/v2 v2.3.0 h1:z2mA1a7tIf5ShggOFlR1oBPgd6hGqcDYsISxZByUzdI=
 github.com/nats-io/jwt/v2 v2.3.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.9.8 h1:jgxZsv+A3Reb3MgwxaINcNq/za8xZInKhDg9Q0cGN1o=
@@ -341,6 +356,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -490,6 +507,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -719,6 +738,7 @@ google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/localdev/terraform/main.tf
+++ b/localdev/terraform/main.tf
@@ -1,5 +1,5 @@
 locals {
-  tfbuddy_base_url = "${chomp(var.ngrok_url)}"
+  tfbuddy_base_url = chomp(var.ngrok_url)
 
   child_tfvars = <<EOF
 parent_vars = {
@@ -67,7 +67,7 @@ resource "local_file" "child_tfvars" {
   for_each = toset(local.child_tf_dirs)
 
   filename = "${each.value}/parent.auto.tfvars"
-  content = local.child_tfvars
+  content  = local.child_tfvars
 }
 
 
@@ -81,5 +81,5 @@ terraform {
 }
 
 provider "tfe" {
-# requires TFC_TOKEN variable is set
+  # requires TFC_TOKEN variable is set
 }

--- a/localdev/terraform/modules/vcs_files/main.tf
+++ b/localdev/terraform/modules/vcs_files/main.tf
@@ -69,6 +69,17 @@ resource "random_integer" "import" {
   keepers = {}
 }
 
+import {
+  to = random_integer.import_replacement
+  id = "15390,2,5"
+}
+
+resource "random_integer" "import_replacement" {
+  min     = 1
+  max     = 5
+  keepers = {}
+}
+
 resource "tls_private_key" "rsa-4096-example" {
   algorithm = "RSA"
   rsa_bits  = 4096

--- a/localdev/terraform/modules/vcs_files/main.tf
+++ b/localdev/terraform/modules/vcs_files/main.tf
@@ -58,6 +58,17 @@ resource "random_pet" "rando" {
   }
 }
 
+import {
+  to = random_integer.import
+  id = "15390,2,5"
+}
+
+resource "random_integer" "import" {
+  min     = 2
+  max     = 5
+  keepers = {}
+}
+
 resource "tls_private_key" "rsa-4096-example" {
   algorithm = "RSA"
   rsa_bits  = 4096

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -139,7 +139,7 @@ var failedPlanSummaryFormat = `
 `
 
 var successPlanSummaryFormat = `
-	* Imports: %d
+  * Imports: %d
   * Additions: %d
   * Changes: %d
   * Destructions: %d`

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -29,7 +29,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 	case tfe.RunApplying:
 		// no extra info
 	case tfe.RunApplied:
-		extraInfo = fmt.Sprintf(successPlanSummaryFormat, run.Apply.ResourceAdditions, run.Apply.ResourceChanges, run.Apply.ResourceDestructions)
+		extraInfo = fmt.Sprintf(successPlanSummaryFormat, run.Apply.ResourceImports, run.Apply.ResourceAdditions, run.Apply.ResourceChanges, run.Apply.ResourceDestructions)
 		if len(run.TargetAddrs) > 0 {
 			extraInfo += needToApplyFullWorkSpace
 			extraInfo += fmt.Sprintf(howToApplyFormat, wsName)
@@ -49,7 +49,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 			extraInfo = "Auto Apply Enabled - plan will automatically Apply if it passes policy checks."
 		}
 	case tfe.RunPlanned:
-		extraInfo = fmt.Sprintf(successPlanSummaryFormat, run.Plan.ResourceAdditions, run.Plan.ResourceChanges, run.Plan.ResourceDestructions)
+		extraInfo = fmt.Sprintf(successPlanSummaryFormat, run.Apply.ResourceImports, run.Plan.ResourceAdditions, run.Plan.ResourceChanges, run.Plan.ResourceDestructions)
 		if !run.AutoApply {
 			if len(run.TargetAddrs) > 0 {
 				extraInfo += fmt.Sprintf(howToApplyFormatWithTarget, strings.Join(run.TargetAddrs, ","), wsName, strings.Join(run.TargetAddrs, ","))
@@ -139,6 +139,7 @@ var failedPlanSummaryFormat = `
 `
 
 var successPlanSummaryFormat = `
+	* Imports: %d
   * Additions: %d
   * Changes: %d
   * Destructions: %d`

--- a/pkg/terraform_plan/plan_parser.go
+++ b/pkg/terraform_plan/plan_parser.go
@@ -59,10 +59,6 @@ func PresentPlanChangesAsMarkdown(b []byte, tfcUrl string) string {
 			tplData.Changes[chg.Address] = processChanges(chg)
 
 		case chg.Change.Actions.Delete():
-			if chg.Change.Importing != nil {
-				tplData.ImportCount += 1
-				tplData.Imports = append(tplData.Imports, chg.Address)
-			}
 			tplData.DestructionCount += 1
 			tplData.Destructions = append(tplData.Destructions, chg.Address)
 

--- a/pkg/terraform_plan/plan_parser.go
+++ b/pkg/terraform_plan/plan_parser.go
@@ -39,6 +39,10 @@ func PresentPlanChangesAsMarkdown(b []byte, tfcUrl string) string {
 		case chg.Change.Actions.NoOp():
 			continue
 
+		case chg.Change.Actions.Import():
+			tplData.ImportCount += 1
+			tplData.Imports = append(tplData.Additions, chg.Address)
+
 		case chg.Change.Actions.Create():
 			tplData.AdditionCount += 1
 			tplData.Additions = append(tplData.Additions, chg.Address)
@@ -122,6 +126,8 @@ func isReplace(chg *tfjson.ResourceChange) bool {
 }
 
 type PlanTemplateData struct {
+	ImportCount    int
+	Imports        []string
 	AdditionCount    int
 	Additions        []string
 	ChangeCount      int

--- a/pkg/terraform_plan/plan_parser.go
+++ b/pkg/terraform_plan/plan_parser.go
@@ -38,11 +38,7 @@ func PresentPlanChangesAsMarkdown(b []byte, tfcUrl string) string {
 		switch {
 		case chg.Change.Actions.NoOp():
 			continue
-
-		case chg.Change.Actions.Import():
-			tplData.ImportCount += 1
-			tplData.Imports = append(tplData.Imports, chg.Address)
-
+			
 		case chg.Change.Actions.Create():
 			tplData.AdditionCount += 1
 			tplData.Additions = append(tplData.Additions, chg.Address)

--- a/pkg/terraform_plan/plan_parser.go
+++ b/pkg/terraform_plan/plan_parser.go
@@ -41,7 +41,7 @@ func PresentPlanChangesAsMarkdown(b []byte, tfcUrl string) string {
 
 		case chg.Change.Actions.Import():
 			tplData.ImportCount += 1
-			tplData.Imports = append(tplData.Additions, chg.Address)
+			tplData.Imports = append(tplData.Imports, chg.Address)
 
 		case chg.Change.Actions.Create():
 			tplData.AdditionCount += 1
@@ -126,8 +126,8 @@ func isReplace(chg *tfjson.ResourceChange) bool {
 }
 
 type PlanTemplateData struct {
-	ImportCount    int
-	Imports        []string
+	ImportCount      int
+	Imports          []string
 	AdditionCount    int
 	Additions        []string
 	ChangeCount      int

--- a/pkg/terraform_plan/plan_parser.go
+++ b/pkg/terraform_plan/plan_parser.go
@@ -35,23 +35,42 @@ func PresentPlanChangesAsMarkdown(b []byte, tfcUrl string) string {
 		TfcUrl:       tfcUrl,
 	}
 	for _, chg := range plan.ResourceChanges {
+
 		switch {
 		case chg.Change.Actions.NoOp():
-			continue
-			
+			// There can be scenarios where a resource can be imported and have nothing else happen to it.
+			if chg.Change.Importing != nil {
+				tplData.ImportCount += 1
+				tplData.Imports = append(tplData.Imports, chg.Address)
+			} else {
+				continue
+			}
+
 		case chg.Change.Actions.Create():
 			tplData.AdditionCount += 1
 			tplData.Additions = append(tplData.Additions, chg.Address)
 
 		case chg.Change.Actions.Update():
+			if chg.Change.Importing != nil {
+				tplData.ImportCount += 1
+				tplData.Imports = append(tplData.Imports, chg.Address)
+			}
 			tplData.ChangeCount += 1
 			tplData.Changes[chg.Address] = processChanges(chg)
 
 		case chg.Change.Actions.Delete():
+			if chg.Change.Importing != nil {
+				tplData.ImportCount += 1
+				tplData.Imports = append(tplData.Imports, chg.Address)
+			}
 			tplData.DestructionCount += 1
 			tplData.Destructions = append(tplData.Destructions, chg.Address)
 
 		case chg.Change.Actions.Replace():
+			if chg.Change.Importing != nil {
+				tplData.ImportCount += 1
+				tplData.Imports = append(tplData.Imports, chg.Address)
+			}
 			tplData.ReplacementCount += 1
 			tplData.Replacements[chg.Address] = processChanges(chg)
 		}

--- a/pkg/terraform_plan/plan_parser_test.go
+++ b/pkg/terraform_plan/plan_parser_test.go
@@ -39,6 +39,12 @@ func Test_parseJSONPlan(t *testing.T) {
 			want:    nil,
 			wantErr: false,
 		},
+		{
+			name:    "import",
+			tfplan:  "testdata/TestPresentPlanChangesAsMarkdown/import.tfplan.json",
+			want:    nil,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -65,6 +71,9 @@ func TestPresentPlanChangesAsMarkdown(t *testing.T) {
 		},
 		{
 			name: "replace",
+		},
+		{
+			name: "import",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/terraform_plan/templates/plan_output.tpl
+++ b/pkg/terraform_plan/templates/plan_output.tpl
@@ -5,7 +5,7 @@
 {{- end}}
 {{ end }}
 
-::airplane_arriving: : <b>Imports:</b> {{.ImportCount}}
+:airplane_arriving: : <b>Imports:</b> {{.ImportCount}}
 <ul>
 {{- range .Imports}}
     <li><code>{{ . }}</code></li>

--- a/pkg/terraform_plan/templates/plan_output.tpl
+++ b/pkg/terraform_plan/templates/plan_output.tpl
@@ -5,6 +5,13 @@
 {{- end}}
 {{ end }}
 
+::airplane_arriving: : <b>Imports:</b> {{.ImportCount}}
+<ul>
+{{- range .Imports}}
+    <li><code>{{ . }}</code></li>
+{{- end}}
+</ul>
+
 :seedling: <b>Additions:</b> {{.AdditionCount}}
 <ul>
 {{- range .Additions}}
@@ -29,7 +36,7 @@
 {{- end}}
 </ul>
 </br>
-<b>Plan: </b> {{.AdditionCount}} to add, {{.ChangeCount}} to change, {{.ReplacementCount}} to replace and {{.DestructionCount}} to destroy.
+<b>Plan: </b> {{.ImportCount}} to import, {{.AdditionCount}} to add, {{.ChangeCount}} to change, {{.ReplacementCount}} to replace and {{.DestructionCount}} to destroy.
 </br>
 
 See [Terraform Cloud Output]({{.TfcUrl}}) for more info.

--- a/pkg/terraform_plan/templates/plan_output.tpl
+++ b/pkg/terraform_plan/templates/plan_output.tpl
@@ -5,7 +5,7 @@
 {{- end}}
 {{ end }}
 
-:airplane_arriving: : <b>Imports:</b> {{.ImportCount}}
+:airplane_arriving: <b>Imports:</b> {{.ImportCount}}
 <ul>
 {{- range .Imports}}
     <li><code>{{ . }}</code></li>

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
@@ -6,7 +6,7 @@
 
 :seedling: <b>Additions:</b> 1
 <ul>
-    <li><code>random_pet.will_it_be_one_more_cat</code></li>
+    <li><code>random_pet.will_it_be_cats</code></li>
 </ul>
 
 :cyclone: <b>Changes:</b> 0

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
@@ -1,8 +1,12 @@
 
 
+:airplane_arriving: <b>Imports:</b> 0
+<ul>
+</ul>
+
 :seedling: <b>Additions:</b> 1
 <ul>
-    <li><code>random_pet.will_it_be_cats</code></li>
+    <li><code>random_pet.will_it_be_one_more_cat</code></li>
 </ul>
 
 :cyclone: <b>Changes:</b> 0
@@ -21,7 +25,7 @@
 <ul>
 </ul>
 </br>
-<b>Plan: </b> 1 to add, 0 to change, 0 to replace and 0 to destroy.
+<b>Plan: </b> 0 to import, 1 to add, 0 to change, 0 to replace and 0 to destroy.
 </br>
 
 See [Terraform Cloud Output](http://app.terraform.io/x/y/z) for more info.

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.tfplan.json
@@ -1,7 +1,30 @@
 {
-  "format_version": "1.2",
-  "terraform_version": "1.5.3",
+  "format_version": "1.0",
+  "terraform_version": "1.1.6",
+  "variables": {
+    "aws_account_id": {
+      "value": "123456789120"
+    },
+    "aws_region": {
+      "value": "us-east-1"
+    },
+    "environment_name": {
+      "value": "dev"
+    },
+    "zapier_environment": {
+      "value": "dev"
+    }
+  },
   "planned_values": {
+    "outputs": {
+      "ecr_repository_url": {
+        "sensitive": false,
+        "value": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy"
+      },
+      "our_pet": {
+        "sensitive": false
+      }
+    },
     "root_module": {
       "resources": [
         {
@@ -12,139 +35,252 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "id": "repeatedly-mentally-ruling-octopus",
-            "keepers": {},
+            "keepers": null,
             "length": 4,
             "prefix": null,
-            "separator": "-"
+            "separator": "/"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
-        },
-        {
-          "address": "random_pet.will_it_be_one_more_cat",
-          "mode": "managed",
-          "type": "random_pet",
-          "name": "will_it_be_one_more_cat",
-          "provider_name": "registry.terraform.io/hashicorp/random",
-          "schema_version": 0,
-          "values": {
-            "keepers": {},
-            "length": 6,
-            "prefix": null,
-            "separator": "-"
-          },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         }
       ],
       "child_modules": [
         {
           "resources": [
             {
-              "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
+              "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
               "mode": "managed",
-              "type": "random_pet",
-              "name": "will_it_be_more_cats",
-              "index": 0,
-              "provider_name": "registry.terraform.io/hashicorp/random",
+              "type": "aws_ecr_lifecycle_policy",
+              "name": "expiration",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
               "schema_version": 0,
               "values": {
-                "id": "immortal-baboon",
-                "keepers": {},
-                "length": 0,
-                "prefix": null,
-                "separator": "-"
+                "id": "tfbuddy",
+                "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
+                "registry_id": "123456789120",
+                "repository": "tfbuddy"
+              },
+              "sensitive_values": {}
+            },
+            {
+              "address": "module.ecr_repository.aws_ecr_repository.repo",
+              "mode": "managed",
+              "type": "aws_ecr_repository",
+              "name": "repo",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
+                "encryption_configuration": [
+                  {
+                    "encryption_type": "AES256",
+                    "kms_key": ""
+                  }
+                ],
+                "id": "tfbuddy",
+                "image_scanning_configuration": [
+                  {
+                    "scan_on_push": true
+                  }
+                ],
+                "image_tag_mutability": "MUTABLE",
+                "name": "tfbuddy",
+                "registry_id": "123456789120",
+                "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+                "tags": {
+                  "managed_by": "terraform",
+                  "name": "tfbuddy",
+                  "service": "tfbuddy"
+                },
+                "tags_all": {
+                  "managed_by": "terraform",
+                  "name": "tfbuddy",
+                  "service": "tfbuddy"
+                },
+                "timeouts": null
               },
               "sensitive_values": {
-                "keepers": {}
+                "encryption_configuration": [
+                  {}
+                ],
+                "image_scanning_configuration": [
+                  {}
+                ],
+                "tags": {},
+                "tags_all": {}
               }
             },
             {
-              "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
+              "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
               "mode": "managed",
-              "type": "random_pet",
-              "name": "will_it_be_more_cats",
-              "index": 1,
-              "provider_name": "registry.terraform.io/hashicorp/random",
+              "type": "aws_ecr_repository_policy",
+              "name": "cross_account",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
               "schema_version": 0,
               "values": {
-                "id": "grouper",
-                "keepers": {},
-                "length": 1,
-                "prefix": null,
-                "separator": "-"
+                "id": "tfbuddy",
+                "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
+                "registry_id": "123456789120",
+                "repository": "tfbuddy"
               },
-              "sensitive_values": {
-                "keepers": {}
-              }
-            },
-            {
-              "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
-              "mode": "managed",
-              "type": "random_pet",
-              "name": "will_it_be_more_cats",
-              "index": 2,
-              "provider_name": "registry.terraform.io/hashicorp/random",
-              "schema_version": 0,
-              "values": {
-                "id": "fit-sturgeon",
-                "keepers": {},
-                "length": 2,
-                "prefix": null,
-                "separator": "-"
-              },
-              "sensitive_values": {
-                "keepers": {}
-              }
-            },
-            {
-              "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
-              "mode": "managed",
-              "type": "random_pet",
-              "name": "will_it_be_more_cats",
-              "index": 3,
-              "provider_name": "registry.terraform.io/hashicorp/random",
-              "schema_version": 0,
-              "values": {
-                "id": "possibly-popular-urchin",
-                "keepers": {},
-                "length": 3,
-                "prefix": null,
-                "separator": "-"
-              },
-              "sensitive_values": {
-                "keepers": {}
-              }
-            },
-            {
-              "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
-              "mode": "managed",
-              "type": "random_pet",
-              "name": "will_it_be_more_cats",
-              "index": 4,
-              "provider_name": "registry.terraform.io/hashicorp/random",
-              "schema_version": 0,
-              "values": {
-                "id": "nationally-noticeably-electric-lab",
-                "keepers": {},
-                "length": 4,
-                "prefix": null,
-                "separator": "-"
-              },
-              "sensitive_values": {
-                "keepers": {}
-              }
+              "sensitive_values": {}
             }
           ],
-          "address": "module.more_cats"
+          "address": "module.ecr_repository"
         }
       ]
     }
   },
   "resource_changes": [
+    {
+      "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
+      "module_address": "module.ecr_repository",
+      "mode": "managed",
+      "type": "aws_ecr_lifecycle_policy",
+      "name": "expiration",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "tfbuddy",
+          "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
+          "registry_id": "123456789120",
+          "repository": "tfbuddy"
+        },
+        "after": {
+          "id": "tfbuddy",
+          "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
+          "registry_id": "123456789120",
+          "repository": "tfbuddy"
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.ecr_repository.aws_ecr_repository.repo",
+      "module_address": "module.ecr_repository",
+      "mode": "managed",
+      "type": "aws_ecr_repository",
+      "name": "repo",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
+          "encryption_configuration": [
+            {
+              "encryption_type": "AES256",
+              "kms_key": ""
+            }
+          ],
+          "id": "tfbuddy",
+          "image_scanning_configuration": [
+            {
+              "scan_on_push": true
+            }
+          ],
+          "image_tag_mutability": "MUTABLE",
+          "name": "tfbuddy",
+          "registry_id": "123456789120",
+          "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+          "tags": {
+            "managed_by": "terraform",
+            "name": "tfbuddy",
+            "service": "tfbuddy"
+          },
+          "tags_all": {
+            "managed_by": "terraform",
+            "name": "tfbuddy",
+            "service": "tfbuddy"
+          },
+          "timeouts": null
+        },
+        "after": {
+          "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
+          "encryption_configuration": [
+            {
+              "encryption_type": "AES256",
+              "kms_key": ""
+            }
+          ],
+          "id": "tfbuddy",
+          "image_scanning_configuration": [
+            {
+              "scan_on_push": true
+            }
+          ],
+          "image_tag_mutability": "MUTABLE",
+          "name": "tfbuddy",
+          "registry_id": "123456789120",
+          "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+          "tags": {
+            "managed_by": "terraform",
+            "name": "tfbuddy",
+            "service": "tfbuddy"
+          },
+          "tags_all": {
+            "managed_by": "terraform",
+            "name": "tfbuddy",
+            "service": "tfbuddy"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "encryption_configuration": [
+            {}
+          ],
+          "image_scanning_configuration": [
+            {}
+          ],
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "encryption_configuration": [
+            {}
+          ],
+          "image_scanning_configuration": [
+            {}
+          ],
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
+      "module_address": "module.ecr_repository",
+      "mode": "managed",
+      "type": "aws_ecr_repository_policy",
+      "name": "cross_account",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "tfbuddy",
+          "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
+          "registry_id": "123456789120",
+          "repository": "tfbuddy"
+        },
+        "after": {
+          "id": "tfbuddy",
+          "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
+          "registry_id": "123456789120",
+          "repository": "tfbuddy"
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    },
     {
       "address": "random_pet.will_it_be_cats",
       "mode": "managed",
@@ -153,359 +289,144 @@
       "provider_name": "registry.terraform.io/hashicorp/random",
       "change": {
         "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "repeatedly-mentally-ruling-octopus",
-          "keepers": {},
-          "length": 4,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "repeatedly-mentally-ruling-octopus",
-          "keepers": {},
-          "length": 4,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "random_pet.will_it_be_one_more_cat",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_one_more_cat",
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
           "create"
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 6,
+          "keepers": null,
+          "length": 4,
           "prefix": null,
-          "separator": "-"
+          "separator": "/"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
-      "module_address": "module.more_cats",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_more_cats",
-      "index": 0,
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "immortal-baboon",
-          "keepers": {},
-          "length": 0,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "immortal-baboon",
-          "keepers": {},
-          "length": 0,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
-      "module_address": "module.more_cats",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_more_cats",
-      "index": 1,
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "grouper",
-          "keepers": {},
-          "length": 1,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "grouper",
-          "keepers": {},
-          "length": 1,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
-      "module_address": "module.more_cats",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_more_cats",
-      "index": 2,
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "fit-sturgeon",
-          "keepers": {},
-          "length": 2,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "fit-sturgeon",
-          "keepers": {},
-          "length": 2,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
-      "module_address": "module.more_cats",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_more_cats",
-      "index": 3,
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "possibly-popular-urchin",
-          "keepers": {},
-          "length": 3,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "possibly-popular-urchin",
-          "keepers": {},
-          "length": 3,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
-      }
-    },
-    {
-      "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
-      "module_address": "module.more_cats",
-      "mode": "managed",
-      "type": "random_pet",
-      "name": "will_it_be_more_cats",
-      "index": 4,
-      "provider_name": "registry.terraform.io/hashicorp/random",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "nationally-noticeably-electric-lab",
-          "keepers": {},
-          "length": 4,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after": {
-          "id": "nationally-noticeably-electric-lab",
-          "keepers": {},
-          "length": 4,
-          "prefix": null,
-          "separator": "-"
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     }
   ],
+  "output_changes": {
+    "ecr_repository_url": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+      "after": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "our_pet": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.5.3",
+    "terraform_version": "1.1.6",
     "values": {
+      "outputs": {
+        "ecr_repository_url": {
+          "sensitive": false,
+          "value": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy"
+        }
+      },
       "root_module": {
-        "resources": [
-          {
-            "address": "random_pet.will_it_be_cats",
-            "mode": "managed",
-            "type": "random_pet",
-            "name": "will_it_be_cats",
-            "provider_name": "registry.terraform.io/hashicorp/random",
-            "schema_version": 0,
-            "values": {
-              "id": "repeatedly-mentally-ruling-octopus",
-              "keepers": {},
-              "length": 4,
-              "prefix": null,
-              "separator": "-"
-            },
-            "sensitive_values": {
-              "keepers": {}
-            }
-          }
-        ],
         "child_modules": [
           {
             "resources": [
               {
-                "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
+                "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
                 "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "index": 0,
-                "provider_name": "registry.terraform.io/hashicorp/random",
+                "type": "aws_ecr_lifecycle_policy",
+                "name": "expiration",
+                "provider_name": "registry.terraform.io/hashicorp/aws",
                 "schema_version": 0,
                 "values": {
-                  "id": "immortal-baboon",
-                  "keepers": {},
-                  "length": 0,
-                  "prefix": null,
-                  "separator": "-"
+                  "id": "tfbuddy",
+                  "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
+                  "registry_id": "123456789120",
+                  "repository": "tfbuddy"
+                },
+                "sensitive_values": {},
+                "depends_on": [
+                  "module.ecr_repository.aws_ecr_repository.repo"
+                ]
+              },
+              {
+                "address": "module.ecr_repository.aws_ecr_repository.repo",
+                "mode": "managed",
+                "type": "aws_ecr_repository",
+                "name": "repo",
+                "provider_name": "registry.terraform.io/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
+                  "encryption_configuration": [
+                    {
+                      "encryption_type": "AES256",
+                      "kms_key": ""
+                    }
+                  ],
+                  "id": "tfbuddy",
+                  "image_scanning_configuration": [
+                    {
+                      "scan_on_push": true
+                    }
+                  ],
+                  "image_tag_mutability": "MUTABLE",
+                  "name": "tfbuddy",
+                  "registry_id": "123456789120",
+                  "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
+                  "tags": {
+                    "managed_by": "terraform",
+                    "name": "tfbuddy",
+                    "service": "tfbuddy"
+                  },
+                  "tags_all": {
+                    "managed_by": "terraform",
+                    "name": "tfbuddy",
+                    "service": "tfbuddy"
+                  },
+                  "timeouts": null
                 },
                 "sensitive_values": {
-                  "keepers": {}
+                  "encryption_configuration": [
+                    {}
+                  ],
+                  "image_scanning_configuration": [
+                    {}
+                  ],
+                  "tags": {},
+                  "tags_all": {}
                 }
               },
               {
-                "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
+                "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
                 "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "index": 1,
-                "provider_name": "registry.terraform.io/hashicorp/random",
+                "type": "aws_ecr_repository_policy",
+                "name": "cross_account",
+                "provider_name": "registry.terraform.io/hashicorp/aws",
                 "schema_version": 0,
                 "values": {
-                  "id": "grouper",
-                  "keepers": {},
-                  "length": 1,
-                  "prefix": null,
-                  "separator": "-"
+                  "id": "tfbuddy",
+                  "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
+                  "registry_id": "123456789120",
+                  "repository": "tfbuddy"
                 },
-                "sensitive_values": {
-                  "keepers": {}
-                }
-              },
-              {
-                "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
-                "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "index": 2,
-                "provider_name": "registry.terraform.io/hashicorp/random",
-                "schema_version": 0,
-                "values": {
-                  "id": "fit-sturgeon",
-                  "keepers": {},
-                  "length": 2,
-                  "prefix": null,
-                  "separator": "-"
-                },
-                "sensitive_values": {
-                  "keepers": {}
-                }
-              },
-              {
-                "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
-                "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "index": 3,
-                "provider_name": "registry.terraform.io/hashicorp/random",
-                "schema_version": 0,
-                "values": {
-                  "id": "possibly-popular-urchin",
-                  "keepers": {},
-                  "length": 3,
-                  "prefix": null,
-                  "separator": "-"
-                },
-                "sensitive_values": {
-                  "keepers": {}
-                }
-              },
-              {
-                "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
-                "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "index": 4,
-                "provider_name": "registry.terraform.io/hashicorp/random",
-                "schema_version": 0,
-                "values": {
-                  "id": "nationally-noticeably-electric-lab",
-                  "keepers": {},
-                  "length": 4,
-                  "prefix": null,
-                  "separator": "-"
-                },
-                "sensitive_values": {
-                  "keepers": {}
-                }
+                "sensitive_values": {},
+                "depends_on": [
+                  "module.ecr_repository.aws_ecr_repository.repo"
+                ]
               }
             ],
-            "address": "module.more_cats"
+            "address": "module.ecr_repository"
           }
         ]
       }
@@ -513,12 +434,39 @@
   },
   "configuration": {
     "provider_config": {
-      "random": {
-        "name": "random",
-        "full_name": "registry.terraform.io/hashicorp/random"
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "allowed_account_ids": {
+            "references": [
+              "var.aws_account_id"
+            ]
+          },
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
       }
     },
     "root_module": {
+      "outputs": {
+        "ecr_repository_url": {
+          "expression": {
+            "references": [
+              "module.ecr_repository.ecr_repository_url",
+              "module.ecr_repository"
+            ]
+          }
+        },
+        "our_pet": {
+          "expression": {
+            "references": [
+              "random_pet.will_it_be_cats.id",
+              "random_pet.will_it_be_cats"
+            ]
+          }
+        }
+      },
       "resources": [
         {
           "address": "random_pet.will_it_be_cats",
@@ -527,63 +475,137 @@
           "name": "will_it_be_cats",
           "provider_config_key": "random",
           "expressions": {
-            "keepers": {
-              "constant_value": {}
-            },
             "length": {
               "constant_value": 4
-            }
-          },
-          "schema_version": 0
-        },
-        {
-          "address": "random_pet.will_it_be_one_more_cat",
-          "mode": "managed",
-          "type": "random_pet",
-          "name": "will_it_be_one_more_cat",
-          "provider_config_key": "random",
-          "expressions": {
-            "keepers": {
-              "constant_value": {}
             },
-            "length": {
-              "constant_value": 6
+            "separator": {
+              "constant_value": "/"
             }
           },
           "schema_version": 0
         }
       ],
       "module_calls": {
-        "more_cats": {
-          "source": "./modules/more_cats",
+        "ecr_repository": {
+          "source": "app.terraform.io/zapier/ecr-repository/aws",
+          "expressions": {
+            "name": {
+              "constant_value": "tfbuddy"
+            },
+            "service": {
+              "constant_value": "tfbuddy"
+            }
+          },
           "module": {
+            "outputs": {
+              "ecr_repository_name": {
+                "expression": {
+                  "references": [
+                    "aws_ecr_repository.repo.name",
+                    "aws_ecr_repository.repo"
+                  ]
+                }
+              },
+              "ecr_repository_url": {
+                "expression": {
+                  "references": [
+                    "aws_ecr_repository.repo.repository_url",
+                    "aws_ecr_repository.repo"
+                  ]
+                }
+              }
+            },
             "resources": [
               {
-                "address": "random_pet.will_it_be_more_cats",
+                "address": "aws_ecr_lifecycle_policy.expiration",
                 "mode": "managed",
-                "type": "random_pet",
-                "name": "will_it_be_more_cats",
-                "provider_config_key": "random",
+                "type": "aws_ecr_lifecycle_policy",
+                "name": "expiration",
+                "provider_config_key": "ecr_repository:aws",
                 "expressions": {
-                  "keepers": {
-                    "constant_value": {}
+                  "policy": {
+                    "constant_value": "{\n    \"rules\": [\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"sinceImagePushed\",\n          \"countUnit\": \"days\",\n          \"countNumber\": 1,\n          \"tagStatus\": \"untagged\"\n        },\n        \"description\": \"remove untagged \u003e 1 days\",\n        \"rulePriority\": 1\n      },\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"sinceImagePushed\",\n          \"countUnit\": \"days\",\n          \"countNumber\": 30,\n          \"tagStatus\": \"tagged\",\n          \"tagPrefixList\": [\"ci-\"]\n        },\n        \"description\": \"remove CI images older than 30 days\",\n        \"rulePriority\": 2\n      },\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"imageCountMoreThan\",\n          \"countNumber\": 4000,\n          \"tagStatus\": \"any\"\n        },\n        \"description\": \"remove any images after we reach 4000 in repo\",\n        \"rulePriority\": 3\n      }\n    ]\n  }\n"
                   },
-                  "length": {
+                  "repository": {
                     "references": [
-                      "count.index"
+                      "aws_ecr_repository.repo.name",
+                      "aws_ecr_repository.repo"
                     ]
                   }
                 },
-                "schema_version": 0,
-                "count_expression": {
-                  "constant_value": 5
-                }
+                "schema_version": 0
+              },
+              {
+                "address": "aws_ecr_repository.repo",
+                "mode": "managed",
+                "type": "aws_ecr_repository",
+                "name": "repo",
+                "provider_config_key": "ecr_repository:aws",
+                "expressions": {
+                  "image_scanning_configuration": [
+                    {
+                      "scan_on_push": {
+                        "constant_value": true
+                      }
+                    }
+                  ],
+                  "name": {
+                    "references": [
+                      "var.name"
+                    ]
+                  },
+                  "tags": {
+                    "references": [
+                      "var.name",
+                      "var.service"
+                    ]
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "aws_ecr_repository_policy.cross_account",
+                "mode": "managed",
+                "type": "aws_ecr_repository_policy",
+                "name": "cross_account",
+                "provider_config_key": "ecr_repository:aws",
+                "expressions": {
+                  "policy": {
+                    "constant_value": "{\n  \"Version\": \"2008-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"AllowPushPull\",\n      \"Effect\": \"Allow\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::123456789120:root\"\n      },\n      \"Action\": [\n        \"ecr:BatchCheckLayerAvailability\",\n        \"ecr:BatchGetImage\",\n        \"ecr:CompleteLayerUpload\",\n        \"ecr:GetDownloadUrlForLayer\",\n        \"ecr:InitiateLayerUpload\",\n        \"ecr:PutImage\",\n        \"ecr:UploadLayerPart\"\n      ]\n    }\n  ]\n}\n"
+                  },
+                  "repository": {
+                    "references": [
+                      "aws_ecr_repository.repo.name",
+                      "aws_ecr_repository.repo"
+                    ]
+                  }
+                },
+                "schema_version": 0
               }
-            ]
-          }
+            ],
+            "variables": {
+              "name": {
+                "description": "The ECR repository name"
+              },
+              "service": {
+                "description": "The Zapier service this repository is for."
+              }
+            }
+          },
+          "version_constraint": "0.1.1"
+        }
+      },
+      "variables": {
+        "aws_account_id": {
+          "default": "123456789120"
+        },
+        "aws_region": {
+          "default": "us-east-1"
+        },
+        "environment_name": {
+          "default": "dev"
         }
       }
     }
-  },
-  "timestamp": "2023-07-20T15:01:12Z"
+  }
 }

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.tfplan.json
@@ -1,30 +1,7 @@
 {
-  "format_version": "1.0",
-  "terraform_version": "1.1.6",
-  "variables": {
-    "aws_account_id": {
-      "value": "123456789120"
-    },
-    "aws_region": {
-      "value": "us-east-1"
-    },
-    "environment_name": {
-      "value": "dev"
-    },
-    "zapier_environment": {
-      "value": "dev"
-    }
-  },
+  "format_version": "1.2",
+  "terraform_version": "1.5.3",
   "planned_values": {
-    "outputs": {
-      "ecr_repository_url": {
-        "sensitive": false,
-        "value": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy"
-      },
-      "our_pet": {
-        "sensitive": false
-      }
-    },
     "root_module": {
       "resources": [
         {
@@ -35,252 +12,139 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
+            "id": "repeatedly-mentally-ruling-octopus",
+            "keepers": {},
             "length": 4,
             "prefix": null,
-            "separator": "/"
+            "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
+        },
+        {
+          "address": "random_pet.will_it_be_one_more_cat",
+          "mode": "managed",
+          "type": "random_pet",
+          "name": "will_it_be_one_more_cat",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 0,
+          "values": {
+            "keepers": {},
+            "length": 6,
+            "prefix": null,
+            "separator": "-"
+          },
+          "sensitive_values": {
+            "keepers": {}
+          }
         }
       ],
       "child_modules": [
         {
           "resources": [
             {
-              "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
               "mode": "managed",
-              "type": "aws_ecr_lifecycle_policy",
-              "name": "expiration",
-              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 0,
+              "provider_name": "registry.terraform.io/hashicorp/random",
               "schema_version": 0,
               "values": {
-                "id": "tfbuddy",
-                "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
-                "registry_id": "123456789120",
-                "repository": "tfbuddy"
-              },
-              "sensitive_values": {}
-            },
-            {
-              "address": "module.ecr_repository.aws_ecr_repository.repo",
-              "mode": "managed",
-              "type": "aws_ecr_repository",
-              "name": "repo",
-              "provider_name": "registry.terraform.io/hashicorp/aws",
-              "schema_version": 0,
-              "values": {
-                "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
-                "encryption_configuration": [
-                  {
-                    "encryption_type": "AES256",
-                    "kms_key": ""
-                  }
-                ],
-                "id": "tfbuddy",
-                "image_scanning_configuration": [
-                  {
-                    "scan_on_push": true
-                  }
-                ],
-                "image_tag_mutability": "MUTABLE",
-                "name": "tfbuddy",
-                "registry_id": "123456789120",
-                "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-                "tags": {
-                  "managed_by": "terraform",
-                  "name": "tfbuddy",
-                  "service": "tfbuddy"
-                },
-                "tags_all": {
-                  "managed_by": "terraform",
-                  "name": "tfbuddy",
-                  "service": "tfbuddy"
-                },
-                "timeouts": null
+                "id": "immortal-baboon",
+                "keepers": {},
+                "length": 0,
+                "prefix": null,
+                "separator": "-"
               },
               "sensitive_values": {
-                "encryption_configuration": [
-                  {}
-                ],
-                "image_scanning_configuration": [
-                  {}
-                ],
-                "tags": {},
-                "tags_all": {}
+                "keepers": {}
               }
             },
             {
-              "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
               "mode": "managed",
-              "type": "aws_ecr_repository_policy",
-              "name": "cross_account",
-              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 1,
+              "provider_name": "registry.terraform.io/hashicorp/random",
               "schema_version": 0,
               "values": {
-                "id": "tfbuddy",
-                "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
-                "registry_id": "123456789120",
-                "repository": "tfbuddy"
+                "id": "grouper",
+                "keepers": {},
+                "length": 1,
+                "prefix": null,
+                "separator": "-"
               },
-              "sensitive_values": {}
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 2,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "id": "fit-sturgeon",
+                "keepers": {},
+                "length": 2,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 3,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "id": "possibly-popular-urchin",
+                "keepers": {},
+                "length": 3,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 4,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "id": "nationally-noticeably-electric-lab",
+                "keepers": {},
+                "length": 4,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
             }
           ],
-          "address": "module.ecr_repository"
+          "address": "module.more_cats"
         }
       ]
     }
   },
   "resource_changes": [
-    {
-      "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
-      "module_address": "module.ecr_repository",
-      "mode": "managed",
-      "type": "aws_ecr_lifecycle_policy",
-      "name": "expiration",
-      "provider_name": "registry.terraform.io/hashicorp/aws",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "tfbuddy",
-          "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
-          "registry_id": "123456789120",
-          "repository": "tfbuddy"
-        },
-        "after": {
-          "id": "tfbuddy",
-          "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
-          "registry_id": "123456789120",
-          "repository": "tfbuddy"
-        },
-        "after_unknown": {},
-        "before_sensitive": {},
-        "after_sensitive": {}
-      }
-    },
-    {
-      "address": "module.ecr_repository.aws_ecr_repository.repo",
-      "module_address": "module.ecr_repository",
-      "mode": "managed",
-      "type": "aws_ecr_repository",
-      "name": "repo",
-      "provider_name": "registry.terraform.io/hashicorp/aws",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
-          "encryption_configuration": [
-            {
-              "encryption_type": "AES256",
-              "kms_key": ""
-            }
-          ],
-          "id": "tfbuddy",
-          "image_scanning_configuration": [
-            {
-              "scan_on_push": true
-            }
-          ],
-          "image_tag_mutability": "MUTABLE",
-          "name": "tfbuddy",
-          "registry_id": "123456789120",
-          "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-          "tags": {
-            "managed_by": "terraform",
-            "name": "tfbuddy",
-            "service": "tfbuddy"
-          },
-          "tags_all": {
-            "managed_by": "terraform",
-            "name": "tfbuddy",
-            "service": "tfbuddy"
-          },
-          "timeouts": null
-        },
-        "after": {
-          "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
-          "encryption_configuration": [
-            {
-              "encryption_type": "AES256",
-              "kms_key": ""
-            }
-          ],
-          "id": "tfbuddy",
-          "image_scanning_configuration": [
-            {
-              "scan_on_push": true
-            }
-          ],
-          "image_tag_mutability": "MUTABLE",
-          "name": "tfbuddy",
-          "registry_id": "123456789120",
-          "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-          "tags": {
-            "managed_by": "terraform",
-            "name": "tfbuddy",
-            "service": "tfbuddy"
-          },
-          "tags_all": {
-            "managed_by": "terraform",
-            "name": "tfbuddy",
-            "service": "tfbuddy"
-          },
-          "timeouts": null
-        },
-        "after_unknown": {},
-        "before_sensitive": {
-          "encryption_configuration": [
-            {}
-          ],
-          "image_scanning_configuration": [
-            {}
-          ],
-          "tags": {},
-          "tags_all": {}
-        },
-        "after_sensitive": {
-          "encryption_configuration": [
-            {}
-          ],
-          "image_scanning_configuration": [
-            {}
-          ],
-          "tags": {},
-          "tags_all": {}
-        }
-      }
-    },
-    {
-      "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
-      "module_address": "module.ecr_repository",
-      "mode": "managed",
-      "type": "aws_ecr_repository_policy",
-      "name": "cross_account",
-      "provider_name": "registry.terraform.io/hashicorp/aws",
-      "change": {
-        "actions": [
-          "no-op"
-        ],
-        "before": {
-          "id": "tfbuddy",
-          "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
-          "registry_id": "123456789120",
-          "repository": "tfbuddy"
-        },
-        "after": {
-          "id": "tfbuddy",
-          "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
-          "registry_id": "123456789120",
-          "repository": "tfbuddy"
-        },
-        "after_unknown": {},
-        "before_sensitive": {},
-        "after_sensitive": {}
-      }
-    },
     {
       "address": "random_pet.will_it_be_cats",
       "mode": "managed",
@@ -289,144 +153,359 @@
       "provider_name": "registry.terraform.io/hashicorp/random",
       "change": {
         "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "repeatedly-mentally-ruling-octopus",
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "repeatedly-mentally-ruling-octopus",
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "random_pet.will_it_be_one_more_cat",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_one_more_cat",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
           "create"
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 4,
+          "keepers": {},
+          "length": 6,
           "prefix": null,
-          "separator": "/"
+          "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "immortal-baboon",
+          "keepers": {},
+          "length": 0,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "immortal-baboon",
+          "keepers": {},
+          "length": 0,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 1,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "grouper",
+          "keepers": {},
+          "length": 1,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "grouper",
+          "keepers": {},
+          "length": 1,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 2,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "fit-sturgeon",
+          "keepers": {},
+          "length": 2,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "fit-sturgeon",
+          "keepers": {},
+          "length": 2,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 3,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "possibly-popular-urchin",
+          "keepers": {},
+          "length": 3,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "possibly-popular-urchin",
+          "keepers": {},
+          "length": 3,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 4,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "nationally-noticeably-electric-lab",
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after": {
+          "id": "nationally-noticeably-electric-lab",
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     }
   ],
-  "output_changes": {
-    "ecr_repository_url": {
-      "actions": [
-        "no-op"
-      ],
-      "before": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-      "after": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-      "after_unknown": false,
-      "before_sensitive": false,
-      "after_sensitive": false
-    },
-    "our_pet": {
-      "actions": [
-        "create"
-      ],
-      "before": null,
-      "after_unknown": true,
-      "before_sensitive": false,
-      "after_sensitive": false
-    }
-  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.1.6",
+    "terraform_version": "1.5.3",
     "values": {
-      "outputs": {
-        "ecr_repository_url": {
-          "sensitive": false,
-          "value": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy"
-        }
-      },
       "root_module": {
+        "resources": [
+          {
+            "address": "random_pet.will_it_be_cats",
+            "mode": "managed",
+            "type": "random_pet",
+            "name": "will_it_be_cats",
+            "provider_name": "registry.terraform.io/hashicorp/random",
+            "schema_version": 0,
+            "values": {
+              "id": "repeatedly-mentally-ruling-octopus",
+              "keepers": {},
+              "length": 4,
+              "prefix": null,
+              "separator": "-"
+            },
+            "sensitive_values": {
+              "keepers": {}
+            }
+          }
+        ],
         "child_modules": [
           {
             "resources": [
               {
-                "address": "module.ecr_repository.aws_ecr_lifecycle_policy.expiration",
+                "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
                 "mode": "managed",
-                "type": "aws_ecr_lifecycle_policy",
-                "name": "expiration",
-                "provider_name": "registry.terraform.io/hashicorp/aws",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "index": 0,
+                "provider_name": "registry.terraform.io/hashicorp/random",
                 "schema_version": 0,
                 "values": {
-                  "id": "tfbuddy",
-                  "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"remove untagged \\u003e 1 days\",\"rulePriority\":1,\"selection\":{\"countNumber\":1,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagStatus\":\"untagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove CI images older than 30 days\",\"rulePriority\":2,\"selection\":{\"countNumber\":30,\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"tagPrefixList\":[\"ci-\"],\"tagStatus\":\"tagged\"}},{\"action\":{\"type\":\"expire\"},\"description\":\"remove any images after we reach 4000 in repo\",\"rulePriority\":3,\"selection\":{\"countNumber\":4000,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
-                  "registry_id": "123456789120",
-                  "repository": "tfbuddy"
-                },
-                "sensitive_values": {},
-                "depends_on": [
-                  "module.ecr_repository.aws_ecr_repository.repo"
-                ]
-              },
-              {
-                "address": "module.ecr_repository.aws_ecr_repository.repo",
-                "mode": "managed",
-                "type": "aws_ecr_repository",
-                "name": "repo",
-                "provider_name": "registry.terraform.io/hashicorp/aws",
-                "schema_version": 0,
-                "values": {
-                  "arn": "arn:aws:ecr:us-east-1:123456789120:repository/tfbuddy",
-                  "encryption_configuration": [
-                    {
-                      "encryption_type": "AES256",
-                      "kms_key": ""
-                    }
-                  ],
-                  "id": "tfbuddy",
-                  "image_scanning_configuration": [
-                    {
-                      "scan_on_push": true
-                    }
-                  ],
-                  "image_tag_mutability": "MUTABLE",
-                  "name": "tfbuddy",
-                  "registry_id": "123456789120",
-                  "repository_url": "123456789120.dkr.ecr.us-east-1.amazonaws.com/tfbuddy",
-                  "tags": {
-                    "managed_by": "terraform",
-                    "name": "tfbuddy",
-                    "service": "tfbuddy"
-                  },
-                  "tags_all": {
-                    "managed_by": "terraform",
-                    "name": "tfbuddy",
-                    "service": "tfbuddy"
-                  },
-                  "timeouts": null
+                  "id": "immortal-baboon",
+                  "keepers": {},
+                  "length": 0,
+                  "prefix": null,
+                  "separator": "-"
                 },
                 "sensitive_values": {
-                  "encryption_configuration": [
-                    {}
-                  ],
-                  "image_scanning_configuration": [
-                    {}
-                  ],
-                  "tags": {},
-                  "tags_all": {}
+                  "keepers": {}
                 }
               },
               {
-                "address": "module.ecr_repository.aws_ecr_repository_policy.cross_account",
+                "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
                 "mode": "managed",
-                "type": "aws_ecr_repository_policy",
-                "name": "cross_account",
-                "provider_name": "registry.terraform.io/hashicorp/aws",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "index": 1,
+                "provider_name": "registry.terraform.io/hashicorp/random",
                 "schema_version": 0,
                 "values": {
-                  "id": "tfbuddy",
-                  "policy": "{\"Statement\":[{\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:BatchGetImage\",\"ecr:CompleteLayerUpload\",\"ecr:GetDownloadUrlForLayer\",\"ecr:InitiateLayerUpload\",\"ecr:PutImage\",\"ecr:UploadLayerPart\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789120:root\"},\"Sid\":\"AllowPushPull\"}],\"Version\":\"2008-10-17\"}",
-                  "registry_id": "123456789120",
-                  "repository": "tfbuddy"
+                  "id": "grouper",
+                  "keepers": {},
+                  "length": 1,
+                  "prefix": null,
+                  "separator": "-"
                 },
-                "sensitive_values": {},
-                "depends_on": [
-                  "module.ecr_repository.aws_ecr_repository.repo"
-                ]
+                "sensitive_values": {
+                  "keepers": {}
+                }
+              },
+              {
+                "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
+                "mode": "managed",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "index": 2,
+                "provider_name": "registry.terraform.io/hashicorp/random",
+                "schema_version": 0,
+                "values": {
+                  "id": "fit-sturgeon",
+                  "keepers": {},
+                  "length": 2,
+                  "prefix": null,
+                  "separator": "-"
+                },
+                "sensitive_values": {
+                  "keepers": {}
+                }
+              },
+              {
+                "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
+                "mode": "managed",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "index": 3,
+                "provider_name": "registry.terraform.io/hashicorp/random",
+                "schema_version": 0,
+                "values": {
+                  "id": "possibly-popular-urchin",
+                  "keepers": {},
+                  "length": 3,
+                  "prefix": null,
+                  "separator": "-"
+                },
+                "sensitive_values": {
+                  "keepers": {}
+                }
+              },
+              {
+                "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
+                "mode": "managed",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "index": 4,
+                "provider_name": "registry.terraform.io/hashicorp/random",
+                "schema_version": 0,
+                "values": {
+                  "id": "nationally-noticeably-electric-lab",
+                  "keepers": {},
+                  "length": 4,
+                  "prefix": null,
+                  "separator": "-"
+                },
+                "sensitive_values": {
+                  "keepers": {}
+                }
               }
             ],
-            "address": "module.ecr_repository"
+            "address": "module.more_cats"
           }
         ]
       }
@@ -434,39 +513,12 @@
   },
   "configuration": {
     "provider_config": {
-      "aws": {
-        "name": "aws",
-        "expressions": {
-          "allowed_account_ids": {
-            "references": [
-              "var.aws_account_id"
-            ]
-          },
-          "region": {
-            "constant_value": "us-east-1"
-          }
-        }
+      "random": {
+        "name": "random",
+        "full_name": "registry.terraform.io/hashicorp/random"
       }
     },
     "root_module": {
-      "outputs": {
-        "ecr_repository_url": {
-          "expression": {
-            "references": [
-              "module.ecr_repository.ecr_repository_url",
-              "module.ecr_repository"
-            ]
-          }
-        },
-        "our_pet": {
-          "expression": {
-            "references": [
-              "random_pet.will_it_be_cats.id",
-              "random_pet.will_it_be_cats"
-            ]
-          }
-        }
-      },
       "resources": [
         {
           "address": "random_pet.will_it_be_cats",
@@ -475,137 +527,63 @@
           "name": "will_it_be_cats",
           "provider_config_key": "random",
           "expressions": {
+            "keepers": {
+              "constant_value": {}
+            },
             "length": {
               "constant_value": 4
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_pet.will_it_be_one_more_cat",
+          "mode": "managed",
+          "type": "random_pet",
+          "name": "will_it_be_one_more_cat",
+          "provider_config_key": "random",
+          "expressions": {
+            "keepers": {
+              "constant_value": {}
             },
-            "separator": {
-              "constant_value": "/"
+            "length": {
+              "constant_value": 6
             }
           },
           "schema_version": 0
         }
       ],
       "module_calls": {
-        "ecr_repository": {
-          "source": "app.terraform.io/zapier/ecr-repository/aws",
-          "expressions": {
-            "name": {
-              "constant_value": "tfbuddy"
-            },
-            "service": {
-              "constant_value": "tfbuddy"
-            }
-          },
+        "more_cats": {
+          "source": "./modules/more_cats",
           "module": {
-            "outputs": {
-              "ecr_repository_name": {
-                "expression": {
-                  "references": [
-                    "aws_ecr_repository.repo.name",
-                    "aws_ecr_repository.repo"
-                  ]
-                }
-              },
-              "ecr_repository_url": {
-                "expression": {
-                  "references": [
-                    "aws_ecr_repository.repo.repository_url",
-                    "aws_ecr_repository.repo"
-                  ]
-                }
-              }
-            },
             "resources": [
               {
-                "address": "aws_ecr_lifecycle_policy.expiration",
+                "address": "random_pet.will_it_be_more_cats",
                 "mode": "managed",
-                "type": "aws_ecr_lifecycle_policy",
-                "name": "expiration",
-                "provider_config_key": "ecr_repository:aws",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "provider_config_key": "random",
                 "expressions": {
-                  "policy": {
-                    "constant_value": "{\n    \"rules\": [\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"sinceImagePushed\",\n          \"countUnit\": \"days\",\n          \"countNumber\": 1,\n          \"tagStatus\": \"untagged\"\n        },\n        \"description\": \"remove untagged \u003e 1 days\",\n        \"rulePriority\": 1\n      },\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"sinceImagePushed\",\n          \"countUnit\": \"days\",\n          \"countNumber\": 30,\n          \"tagStatus\": \"tagged\",\n          \"tagPrefixList\": [\"ci-\"]\n        },\n        \"description\": \"remove CI images older than 30 days\",\n        \"rulePriority\": 2\n      },\n      {\n        \"action\": {\n          \"type\": \"expire\"\n        },\n        \"selection\": {\n          \"countType\": \"imageCountMoreThan\",\n          \"countNumber\": 4000,\n          \"tagStatus\": \"any\"\n        },\n        \"description\": \"remove any images after we reach 4000 in repo\",\n        \"rulePriority\": 3\n      }\n    ]\n  }\n"
+                  "keepers": {
+                    "constant_value": {}
                   },
-                  "repository": {
+                  "length": {
                     "references": [
-                      "aws_ecr_repository.repo.name",
-                      "aws_ecr_repository.repo"
+                      "count.index"
                     ]
                   }
                 },
-                "schema_version": 0
-              },
-              {
-                "address": "aws_ecr_repository.repo",
-                "mode": "managed",
-                "type": "aws_ecr_repository",
-                "name": "repo",
-                "provider_config_key": "ecr_repository:aws",
-                "expressions": {
-                  "image_scanning_configuration": [
-                    {
-                      "scan_on_push": {
-                        "constant_value": true
-                      }
-                    }
-                  ],
-                  "name": {
-                    "references": [
-                      "var.name"
-                    ]
-                  },
-                  "tags": {
-                    "references": [
-                      "var.name",
-                      "var.service"
-                    ]
-                  }
-                },
-                "schema_version": 0
-              },
-              {
-                "address": "aws_ecr_repository_policy.cross_account",
-                "mode": "managed",
-                "type": "aws_ecr_repository_policy",
-                "name": "cross_account",
-                "provider_config_key": "ecr_repository:aws",
-                "expressions": {
-                  "policy": {
-                    "constant_value": "{\n  \"Version\": \"2008-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"AllowPushPull\",\n      \"Effect\": \"Allow\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::123456789120:root\"\n      },\n      \"Action\": [\n        \"ecr:BatchCheckLayerAvailability\",\n        \"ecr:BatchGetImage\",\n        \"ecr:CompleteLayerUpload\",\n        \"ecr:GetDownloadUrlForLayer\",\n        \"ecr:InitiateLayerUpload\",\n        \"ecr:PutImage\",\n        \"ecr:UploadLayerPart\"\n      ]\n    }\n  ]\n}\n"
-                  },
-                  "repository": {
-                    "references": [
-                      "aws_ecr_repository.repo.name",
-                      "aws_ecr_repository.repo"
-                    ]
-                  }
-                },
-                "schema_version": 0
+                "schema_version": 0,
+                "count_expression": {
+                  "constant_value": 5
+                }
               }
-            ],
-            "variables": {
-              "name": {
-                "description": "The ECR repository name"
-              },
-              "service": {
-                "description": "The Zapier service this repository is for."
-              }
-            }
-          },
-          "version_constraint": "0.1.1"
-        }
-      },
-      "variables": {
-        "aws_account_id": {
-          "default": "123456789120"
-        },
-        "aws_region": {
-          "default": "us-east-1"
-        },
-        "environment_name": {
-          "default": "dev"
+            ]
+          }
         }
       }
     }
-  }
+  },
+  "timestamp": "2023-07-20T15:01:12Z"
 }

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.md
@@ -1,5 +1,9 @@
 
 
+:airplane_arriving: <b>Imports:</b> 0
+<ul>
+</ul>
+
 :seedling: <b>Additions:</b> 9
 <ul>
     <li><code>random_pet.will_it_be_cats[1]</code></li>
@@ -31,7 +35,7 @@
 <ul>
 </ul>
 </br>
-<b>Plan: </b> 9 to add, 0 to change, 1 to replace and 0 to destroy.
+<b>Plan: </b> 0 to import, 9 to add, 0 to change, 1 to replace and 0 to destroy.
 </br>
 
 See [Terraform Cloud Output](http://app.terraform.io/x/y/z) for more info.

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.tfplan.json
@@ -1,7 +1,23 @@
 {
-  "format_version": "1.2",
-  "terraform_version": "1.5.3",
+  "format_version": "1.0",
+  "terraform_version": "1.1.3",
+  "variables": {
+    "aws_account_id": {
+      "value": "12345678910"
+    },
+    "aws_region": {
+      "value": "us-east-1"
+    },
+    "environment_name": {
+      "value": "dev"
+    }
+  },
   "planned_values": {
+    "outputs": {
+      "our_pets": {
+        "sensitive": false
+      }
+    },
     "root_module": {
       "resources": [
         {
@@ -13,14 +29,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[1]",
@@ -31,14 +45,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[2]",
@@ -49,14 +61,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[3]",
@@ -67,14 +77,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[4]",
@@ -85,14 +93,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[5]",
@@ -103,14 +109,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[6]",
@@ -121,14 +125,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[7]",
@@ -139,14 +141,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[8]",
@@ -157,14 +157,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.will_it_be_cats[9]",
@@ -175,16 +173,15 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": {},
-            "length": 2,
+            "keepers": null,
+            "length": 3,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         }
-      ]
+      ],
+      "child_modules": []
     }
   },
   "resource_changes": [
@@ -202,28 +199,23 @@
           "create"
         ],
         "before": {
-          "id": "suddenly-cleanly-secure-parakeet",
-          "keepers": {},
+          "id": "terminally-eminently-proper-donkey",
+          "keepers": null,
           "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
           [
             "length"
@@ -245,19 +237,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -273,19 +262,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -301,19 +287,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -329,19 +312,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -357,19 +337,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -385,19 +362,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -413,19 +387,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -441,19 +412,16 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     },
     {
@@ -469,26 +437,50 @@
         ],
         "before": null,
         "after": {
-          "keepers": {},
-          "length": 2,
+          "keepers": null,
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": {}
+          "id": true
         },
         "before_sensitive": false,
-        "after_sensitive": {
-          "keepers": {}
-        }
+        "after_sensitive": {}
       }
     }
   ],
+  "output_changes": {
+    "our_pet": {
+      "actions": [
+        "delete"
+      ],
+      "before": "terminally-eminently-proper-donkey",
+      "after": null,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "our_pets": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.5.3",
+    "terraform_version": "1.1.3",
     "values": {
+      "outputs": {
+        "our_pet": {
+          "sensitive": false,
+          "value": "terminally-eminently-proper-donkey"
+        }
+      },
       "root_module": {
         "resources": [
           {
@@ -500,28 +492,45 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "suddenly-cleanly-secure-parakeet",
-              "keepers": {},
+              "id": "terminally-eminently-proper-donkey",
+              "keepers": null,
               "length": 4,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {
-              "keepers": {}
-            }
+            "sensitive_values": {}
           }
-        ]
+        ],
+        "child_modules": []
       }
     }
   },
   "configuration": {
     "provider_config": {
-      "random": {
-        "name": "random",
-        "full_name": "registry.terraform.io/hashicorp/random"
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "allowed_account_ids": {
+            "constant_value": [
+              12345678910
+            ]
+          },
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
       }
     },
     "root_module": {
+      "outputs": {
+        "our_pets": {
+          "expression": {
+            "references": [
+              "random_pet.will_it_be_cats"
+            ]
+          }
+        }
+      },
       "resources": [
         {
           "address": "random_pet.will_it_be_cats",
@@ -530,11 +539,11 @@
           "name": "will_it_be_cats",
           "provider_config_key": "random",
           "expressions": {
-            "keepers": {
-              "constant_value": {}
-            },
             "length": {
-              "constant_value": 2
+              "constant_value": 3
+            },
+            "separator": {
+              "constant_value": "-"
             }
           },
           "schema_version": 0,
@@ -542,8 +551,19 @@
             "constant_value": 10
           }
         }
-      ]
+      ],
+      "module_calls": {},
+      "variables": {
+        "aws_account_id": {
+          "default": "12345678910"
+        },
+        "aws_region": {
+          "default": "us-east-1"
+        },
+        "environment_name": {
+          "default": "dev"
+        }
+      }
     }
-  },
-  "timestamp": "2023-07-20T15:04:40Z"
+  }
 }

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.tfplan.json
@@ -1,23 +1,7 @@
 {
-  "format_version": "1.0",
-  "terraform_version": "1.1.3",
-  "variables": {
-    "aws_account_id": {
-      "value": "12345678910"
-    },
-    "aws_region": {
-      "value": "us-east-1"
-    },
-    "environment_name": {
-      "value": "dev"
-    }
-  },
+  "format_version": "1.2",
+  "terraform_version": "1.5.3",
   "planned_values": {
-    "outputs": {
-      "our_pets": {
-        "sensitive": false
-      }
-    },
     "root_module": {
       "resources": [
         {
@@ -29,12 +13,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[1]",
@@ -45,12 +31,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[2]",
@@ -61,12 +49,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[3]",
@@ -77,12 +67,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[4]",
@@ -93,12 +85,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[5]",
@@ -109,12 +103,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[6]",
@@ -125,12 +121,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[7]",
@@ -141,12 +139,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[8]",
@@ -157,12 +157,14 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.will_it_be_cats[9]",
@@ -173,15 +175,16 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 3,
+            "keepers": {},
+            "length": 2,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         }
-      ],
-      "child_modules": []
+      ]
     }
   },
   "resource_changes": [
@@ -199,23 +202,28 @@
           "create"
         ],
         "before": {
-          "id": "terminally-eminently-proper-donkey",
-          "keepers": null,
+          "id": "suddenly-cleanly-secure-parakeet",
+          "keepers": {},
           "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
           [
             "length"
@@ -237,16 +245,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -262,16 +273,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -287,16 +301,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -312,16 +329,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -337,16 +357,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -362,16 +385,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -387,16 +413,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -412,16 +441,19 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     },
     {
@@ -437,50 +469,26 @@
         ],
         "before": null,
         "after": {
-          "keepers": null,
-          "length": 3,
+          "keepers": {},
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": {}
         },
         "before_sensitive": false,
-        "after_sensitive": {}
+        "after_sensitive": {
+          "keepers": {}
+        }
       }
     }
   ],
-  "output_changes": {
-    "our_pet": {
-      "actions": [
-        "delete"
-      ],
-      "before": "terminally-eminently-proper-donkey",
-      "after": null,
-      "after_unknown": false,
-      "before_sensitive": false,
-      "after_sensitive": false
-    },
-    "our_pets": {
-      "actions": [
-        "create"
-      ],
-      "before": null,
-      "after_unknown": true,
-      "before_sensitive": false,
-      "after_sensitive": false
-    }
-  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.1.3",
+    "terraform_version": "1.5.3",
     "values": {
-      "outputs": {
-        "our_pet": {
-          "sensitive": false,
-          "value": "terminally-eminently-proper-donkey"
-        }
-      },
       "root_module": {
         "resources": [
           {
@@ -492,45 +500,28 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "terminally-eminently-proper-donkey",
-              "keepers": null,
+              "id": "suddenly-cleanly-secure-parakeet",
+              "keepers": {},
               "length": 4,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            }
           }
-        ],
-        "child_modules": []
+        ]
       }
     }
   },
   "configuration": {
     "provider_config": {
-      "aws": {
-        "name": "aws",
-        "expressions": {
-          "allowed_account_ids": {
-            "constant_value": [
-              12345678910
-            ]
-          },
-          "region": {
-            "constant_value": "us-east-1"
-          }
-        }
+      "random": {
+        "name": "random",
+        "full_name": "registry.terraform.io/hashicorp/random"
       }
     },
     "root_module": {
-      "outputs": {
-        "our_pets": {
-          "expression": {
-            "references": [
-              "random_pet.will_it_be_cats"
-            ]
-          }
-        }
-      },
       "resources": [
         {
           "address": "random_pet.will_it_be_cats",
@@ -539,11 +530,11 @@
           "name": "will_it_be_cats",
           "provider_config_key": "random",
           "expressions": {
-            "length": {
-              "constant_value": 3
+            "keepers": {
+              "constant_value": {}
             },
-            "separator": {
-              "constant_value": "-"
+            "length": {
+              "constant_value": 2
             }
           },
           "schema_version": 0,
@@ -551,19 +542,8 @@
             "constant_value": 10
           }
         }
-      ],
-      "module_calls": {},
-      "variables": {
-        "aws_account_id": {
-          "default": "12345678910"
-        },
-        "aws_region": {
-          "default": "us-east-1"
-        },
-        "environment_name": {
-          "default": "dev"
-        }
-      }
+      ]
     }
-  }
+  },
+  "timestamp": "2023-07-20T15:04:40Z"
 }

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
@@ -1,7 +1,8 @@
 
 
-:airplane_arriving: <b>Imports:</b> 0
+:airplane_arriving: <b>Imports:</b> 1
 <ul>
+    <li><code>random_integer.import</code></li>
 </ul>
 
 :seedling: <b>Additions:</b> 6
@@ -30,7 +31,7 @@
 <ul>
 </ul>
 </br>
-<b>Plan: </b> 0 to import, 6 to add, 0 to change, 0 to replace and 0 to destroy.
+<b>Plan: </b> 1 to import, 6 to add, 0 to change, 0 to replace and 0 to destroy.
 </br>
 
 See [Terraform Cloud Output](http://app.terraform.io/x/y/z) for more info.

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
@@ -1,0 +1,37 @@
+
+
+:airplane_arriving: <b>Imports:</b> 0
+<ul>
+</ul>
+
+:seedling: <b>Additions:</b> 6
+<ul>
+    <li><code>random_pet.will_it_be_cats</code></li>
+    <li><code>module.more_cats.random_pet.will_it_be_more_cats[0]</code></li>
+    <li><code>module.more_cats.random_pet.will_it_be_more_cats[1]</code></li>
+    <li><code>module.more_cats.random_pet.will_it_be_more_cats[2]</code></li>
+    <li><code>module.more_cats.random_pet.will_it_be_more_cats[3]</code></li>
+    <li><code>module.more_cats.random_pet.will_it_be_more_cats[4]</code></li>
+</ul>
+
+:cyclone: <b>Changes:</b> 0
+<ul>
+
+
+</ul>
+
+:recycle: <b>Replacements:</b> 0
+<ul>
+
+
+</ul>
+
+:boom: <b>Destructions:</b> 0
+<ul>
+</ul>
+</br>
+<b>Plan: </b> 0 to import, 6 to add, 0 to change, 0 to replace and 0 to destroy.
+</br>
+
+See [Terraform Cloud Output](http://app.terraform.io/x/y/z) for more info.
+

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.tfplan.json
@@ -1,0 +1,462 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.5.3",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "random_integer.import",
+          "mode": "managed",
+          "type": "random_integer",
+          "name": "import",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 0,
+          "values": {
+            "id": "15390",
+            "keepers": {},
+            "max": 5,
+            "min": 2,
+            "result": 15390,
+            "seed": null
+          },
+          "sensitive_values": {
+            "keepers": {}
+          }
+        },
+        {
+          "address": "random_pet.will_it_be_cats",
+          "mode": "managed",
+          "type": "random_pet",
+          "name": "will_it_be_cats",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 0,
+          "values": {
+            "keepers": {},
+            "length": 4,
+            "prefix": null,
+            "separator": "-"
+          },
+          "sensitive_values": {
+            "keepers": {}
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 0,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "keepers": {},
+                "length": 0,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 1,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "keepers": {},
+                "length": 1,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 2,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "keepers": {},
+                "length": 2,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 3,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "keepers": {},
+                "length": 3,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            },
+            {
+              "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
+              "mode": "managed",
+              "type": "random_pet",
+              "name": "will_it_be_more_cats",
+              "index": 4,
+              "provider_name": "registry.terraform.io/hashicorp/random",
+              "schema_version": 0,
+              "values": {
+                "keepers": {},
+                "length": 4,
+                "prefix": null,
+                "separator": "-"
+              },
+              "sensitive_values": {
+                "keepers": {}
+              }
+            }
+          ],
+          "address": "module.more_cats"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "random_integer.import",
+      "mode": "managed",
+      "type": "random_integer",
+      "name": "import",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "15390",
+          "keepers": {},
+          "max": 5,
+          "min": 2,
+          "result": 15390,
+          "seed": null
+        },
+        "after": {
+          "id": "15390",
+          "keepers": {},
+          "max": 5,
+          "min": 2,
+          "result": 15390,
+          "seed": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
+        "importing": {
+          "id": "15390,2,5"
+        }
+      }
+    },
+    {
+      "address": "random_pet.will_it_be_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_cats",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[0]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 0,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[1]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 1,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 1,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[2]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 2,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 2,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[3]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 3,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 3,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    },
+    {
+      "address": "module.more_cats.random_pet.will_it_be_more_cats[4]",
+      "module_address": "module.more_cats",
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "will_it_be_more_cats",
+      "index": 4,
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "keepers": {},
+          "length": 4,
+          "prefix": null,
+          "separator": "-"
+        },
+        "after_unknown": {
+          "id": true,
+          "keepers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "keepers": {}
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.5.3",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "random_integer.import",
+            "mode": "managed",
+            "type": "random_integer",
+            "name": "import",
+            "provider_name": "registry.terraform.io/hashicorp/random",
+            "schema_version": 0,
+            "values": {
+              "id": "15390",
+              "keepers": {},
+              "max": 5,
+              "min": 2,
+              "result": 15390,
+              "seed": null
+            },
+            "sensitive_values": {
+              "keepers": {}
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "random": {
+        "name": "random",
+        "full_name": "registry.terraform.io/hashicorp/random"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "random_integer.import",
+          "mode": "managed",
+          "type": "random_integer",
+          "name": "import",
+          "provider_config_key": "random",
+          "expressions": {
+            "keepers": {
+              "constant_value": {}
+            },
+            "max": {
+              "constant_value": 5
+            },
+            "min": {
+              "constant_value": 2
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_pet.will_it_be_cats",
+          "mode": "managed",
+          "type": "random_pet",
+          "name": "will_it_be_cats",
+          "provider_config_key": "random",
+          "expressions": {
+            "keepers": {
+              "constant_value": {}
+            },
+            "length": {
+              "constant_value": 4
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "module_calls": {
+        "more_cats": {
+          "source": "./modules/more_cats",
+          "module": {
+            "resources": [
+              {
+                "address": "random_pet.will_it_be_more_cats",
+                "mode": "managed",
+                "type": "random_pet",
+                "name": "will_it_be_more_cats",
+                "provider_config_key": "random",
+                "expressions": {
+                  "keepers": {
+                    "constant_value": {}
+                  },
+                  "length": {
+                    "references": [
+                      "count.index"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "constant_value": 5
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "timestamp": "2023-07-20T15:17:32Z"
+}

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.md
@@ -1,5 +1,9 @@
 
 
+:airplane_arriving: <b>Imports:</b> 0
+<ul>
+</ul>
+
 :seedling: <b>Additions:</b> 1
 <ul>
     <li><code>time_rotating.moar_pets</code></li>
@@ -31,7 +35,7 @@
 <ul>
 </ul>
 </br>
-<b>Plan: </b> 1 to add, 0 to change, 5 to replace and 0 to destroy.
+<b>Plan: </b> 0 to import, 1 to add, 0 to change, 5 to replace and 0 to destroy.
 </br>
 
 See [Terraform Cloud Output](http://app.terraform.io/x/y/z) for more info.

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.tfplan.json
@@ -1,7 +1,12 @@
 {
-  "format_version": "1.2",
-  "terraform_version": "1.5.3",
+  "format_version": "1.1",
+  "terraform_version": "1.2.1",
   "planned_values": {
+    "outputs": {
+      "pets": {
+        "sensitive": false
+      }
+    },
     "root_module": {
       "resources": [
         {
@@ -12,12 +17,13 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
             "max": 5,
-            "min": 1,
+            "min": 2,
             "seed": null
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.rando[0]",
@@ -28,12 +34,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.rando[1]",
@@ -44,12 +50,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.rando[2]",
@@ -60,12 +66,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "random_pet.rando[3]",
@@ -76,12 +82,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
-            "keepers": null,
-            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {}
+          "sensitive_values": {
+            "keepers": {}
+          }
         },
         {
           "address": "time_rotating.moar_pets",
@@ -91,9 +97,9 @@
           "provider_name": "registry.terraform.io/hashicorp/time",
           "schema_version": 0,
           "values": {
-            "rotation_days": 30,
+            "rotation_days": null,
             "rotation_hours": null,
-            "rotation_minutes": null,
+            "rotation_minutes": 1,
             "rotation_months": null,
             "rotation_years": null,
             "triggers": null
@@ -103,6 +109,42 @@
       ]
     }
   },
+  "resource_drift": [
+    {
+      "address": "time_rotating.moar_pets",
+      "mode": "managed",
+      "type": "time_rotating",
+      "name": "moar_pets",
+      "provider_name": "registry.terraform.io/hashicorp/time",
+      "change": {
+        "actions": [
+          "delete"
+        ],
+        "before": {
+          "day": 25,
+          "hour": 1,
+          "id": "2022-05-25T01:23:59Z",
+          "minute": 23,
+          "month": 5,
+          "rfc3339": "2022-05-25T01:23:59Z",
+          "rotation_days": null,
+          "rotation_hours": null,
+          "rotation_minutes": 1,
+          "rotation_months": null,
+          "rotation_rfc3339": "2022-05-25T01:24:59Z",
+          "rotation_years": null,
+          "second": 59,
+          "triggers": null,
+          "unix": 1653441839,
+          "year": 2022
+        },
+        "after": null,
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": false
+      }
+    }
+  ],
   "resource_changes": [
     {
       "address": "random_integer.pet_length",
@@ -116,28 +158,34 @@
           "create"
         ],
         "before": {
-          "id": "2",
-          "keepers": null,
+          "id": "3",
+          "keepers": {
+            "rotate": "2022-05-25T01:23:59Z"
+          },
           "max": 5,
           "min": 2,
-          "result": 2,
+          "result": 3,
           "seed": null
         },
         "after": {
-          "keepers": null,
           "max": 5,
-          "min": 1,
+          "min": 2,
           "seed": null
         },
         "after_unknown": {
           "id": true,
+          "keepers": true,
           "result": true
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
           [
-            "min"
+            "keepers"
           ]
         ]
       },
@@ -156,24 +204,33 @@
           "create"
         ],
         "before": {
-          "id": "selected-chimp",
-          "keepers": null,
-          "length": 2,
+          "id": "solely-on-hog",
+          "keepers": {
+            "rotate": "2022-05-25T01:23:59Z"
+          },
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": null,
-          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": true,
+          "length": true
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
+          [
+            "keepers"
+          ],
           [
             "length"
           ]
@@ -194,24 +251,33 @@
           "create"
         ],
         "before": {
-          "id": "regular-kodiak",
-          "keepers": null,
-          "length": 2,
+          "id": "trivially-more-raven",
+          "keepers": {
+            "rotate": "2022-05-25T01:23:59Z"
+          },
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": null,
-          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": true,
+          "length": true
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
+          [
+            "keepers"
+          ],
           [
             "length"
           ]
@@ -232,24 +298,33 @@
           "create"
         ],
         "before": {
-          "id": "fit-crappie",
-          "keepers": null,
-          "length": 2,
+          "id": "nationally-unique-mantis",
+          "keepers": {
+            "rotate": "2022-05-25T01:23:59Z"
+          },
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": null,
-          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": true,
+          "length": true
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
+          [
+            "keepers"
+          ],
           [
             "length"
           ]
@@ -270,24 +345,33 @@
           "create"
         ],
         "before": {
-          "id": "meet-jaguar",
-          "keepers": null,
-          "length": 2,
+          "id": "entirely-present-leech",
+          "keepers": {
+            "rotate": "2022-05-25T01:23:59Z"
+          },
+          "length": 3,
           "prefix": null,
           "separator": "-"
         },
         "after": {
-          "keepers": null,
-          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true
+          "id": true,
+          "keepers": true,
+          "length": true
         },
-        "before_sensitive": {},
-        "after_sensitive": {},
+        "before_sensitive": {
+          "keepers": {}
+        },
+        "after_sensitive": {
+          "keepers": {}
+        },
         "replace_paths": [
+          [
+            "keepers"
+          ],
           [
             "length"
           ]
@@ -307,9 +391,9 @@
         ],
         "before": null,
         "after": {
-          "rotation_days": 30,
+          "rotation_days": null,
           "rotation_hours": null,
-          "rotation_minutes": null,
+          "rotation_minutes": 1,
           "rotation_months": null,
           "rotation_years": null,
           "triggers": null
@@ -331,10 +415,46 @@
       }
     }
   ],
+  "output_changes": {
+    "pets": {
+      "actions": [
+        "update"
+      ],
+      "before": [
+        "solely-on-hog",
+        "trivially-more-raven",
+        "nationally-unique-mantis",
+        "entirely-present-leech"
+      ],
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.5.3",
+    "terraform_version": "1.2.1",
     "values": {
+      "outputs": {
+        "pets": {
+          "sensitive": false,
+          "value": [
+            "solely-on-hog",
+            "trivially-more-raven",
+            "nationally-unique-mantis",
+            "entirely-present-leech"
+          ],
+          "type": [
+            "tuple",
+            [
+              "string",
+              "string",
+              "string",
+              "string"
+            ]
+          ]
+        }
+      },
       "root_module": {
         "resources": [
           {
@@ -345,14 +465,21 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "2",
-              "keepers": null,
+              "id": "3",
+              "keepers": {
+                "rotate": "2022-05-25T01:23:59Z"
+              },
               "max": 5,
               "min": 2,
-              "result": 2,
+              "result": 3,
               "seed": null
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            },
+            "depends_on": [
+              "time_rotating.moar_pets"
+            ]
           },
           {
             "address": "random_pet.rando[0]",
@@ -363,13 +490,21 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "selected-chimp",
-              "keepers": null,
-              "length": 2,
+              "id": "solely-on-hog",
+              "keepers": {
+                "rotate": "2022-05-25T01:23:59Z"
+              },
+              "length": 3,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            },
+            "depends_on": [
+              "random_integer.pet_length",
+              "time_rotating.moar_pets"
+            ]
           },
           {
             "address": "random_pet.rando[1]",
@@ -380,13 +515,21 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "regular-kodiak",
-              "keepers": null,
-              "length": 2,
+              "id": "trivially-more-raven",
+              "keepers": {
+                "rotate": "2022-05-25T01:23:59Z"
+              },
+              "length": 3,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            },
+            "depends_on": [
+              "random_integer.pet_length",
+              "time_rotating.moar_pets"
+            ]
           },
           {
             "address": "random_pet.rando[2]",
@@ -397,13 +540,21 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "fit-crappie",
-              "keepers": null,
-              "length": 2,
+              "id": "nationally-unique-mantis",
+              "keepers": {
+                "rotate": "2022-05-25T01:23:59Z"
+              },
+              "length": 3,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            },
+            "depends_on": [
+              "random_integer.pet_length",
+              "time_rotating.moar_pets"
+            ]
           },
           {
             "address": "random_pet.rando[3]",
@@ -414,13 +565,21 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "meet-jaguar",
-              "keepers": null,
-              "length": 2,
+              "id": "entirely-present-leech",
+              "keepers": {
+                "rotate": "2022-05-25T01:23:59Z"
+              },
+              "length": 3,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {}
+            "sensitive_values": {
+              "keepers": {}
+            },
+            "depends_on": [
+              "random_integer.pet_length",
+              "time_rotating.moar_pets"
+            ]
           }
         ]
       }
@@ -438,6 +597,15 @@
       }
     },
     "root_module": {
+      "outputs": {
+        "pets": {
+          "expression": {
+            "references": [
+              "random_pet.rando"
+            ]
+          }
+        }
+      },
       "resources": [
         {
           "address": "random_integer.pet_length",
@@ -446,11 +614,17 @@
           "name": "pet_length",
           "provider_config_key": "random",
           "expressions": {
+            "keepers": {
+              "references": [
+                "time_rotating.moar_pets.id",
+                "time_rotating.moar_pets"
+              ]
+            },
             "max": {
               "constant_value": 5
             },
             "min": {
-              "constant_value": 1
+              "constant_value": 2
             }
           },
           "schema_version": 0
@@ -462,8 +636,20 @@
           "name": "rando",
           "provider_config_key": "random",
           "expressions": {
+            "keepers": {
+              "references": [
+                "time_rotating.moar_pets.id",
+                "time_rotating.moar_pets"
+              ]
+            },
             "length": {
-              "constant_value": 4
+              "references": [
+                "random_integer.pet_length.result",
+                "random_integer.pet_length"
+              ]
+            },
+            "separator": {
+              "constant_value": "-"
             }
           },
           "schema_version": 0,
@@ -478,8 +664,8 @@
           "name": "moar_pets",
           "provider_config_key": "time",
           "expressions": {
-            "rotation_days": {
-              "constant_value": 30
+            "rotation_minutes": {
+              "constant_value": 1
             }
           },
           "schema_version": 0
@@ -487,5 +673,22 @@
       ]
     }
   },
-  "timestamp": "2023-07-20T15:11:25Z"
+  "relevant_attributes": [
+    {
+      "resource": "random_pet.rando",
+      "attribute": []
+    },
+    {
+      "resource": "time_rotating.moar_pets",
+      "attribute": [
+        "id"
+      ]
+    },
+    {
+      "resource": "random_integer.pet_length",
+      "attribute": [
+        "result"
+      ]
+    }
+  ]
 }

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.tfplan.json
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.tfplan.json
@@ -1,12 +1,7 @@
 {
-  "format_version": "1.1",
-  "terraform_version": "1.2.1",
+  "format_version": "1.2",
+  "terraform_version": "1.5.3",
   "planned_values": {
-    "outputs": {
-      "pets": {
-        "sensitive": false
-      }
-    },
     "root_module": {
       "resources": [
         {
@@ -17,13 +12,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
+            "keepers": null,
             "max": 5,
-            "min": 2,
+            "min": 1,
             "seed": null
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.rando[0]",
@@ -34,12 +28,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
+            "keepers": null,
+            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.rando[1]",
@@ -50,12 +44,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
+            "keepers": null,
+            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.rando[2]",
@@ -66,12 +60,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
+            "keepers": null,
+            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "random_pet.rando[3]",
@@ -82,12 +76,12 @@
           "provider_name": "registry.terraform.io/hashicorp/random",
           "schema_version": 0,
           "values": {
+            "keepers": null,
+            "length": 4,
             "prefix": null,
             "separator": "-"
           },
-          "sensitive_values": {
-            "keepers": {}
-          }
+          "sensitive_values": {}
         },
         {
           "address": "time_rotating.moar_pets",
@@ -97,9 +91,9 @@
           "provider_name": "registry.terraform.io/hashicorp/time",
           "schema_version": 0,
           "values": {
-            "rotation_days": null,
+            "rotation_days": 30,
             "rotation_hours": null,
-            "rotation_minutes": 1,
+            "rotation_minutes": null,
             "rotation_months": null,
             "rotation_years": null,
             "triggers": null
@@ -109,42 +103,6 @@
       ]
     }
   },
-  "resource_drift": [
-    {
-      "address": "time_rotating.moar_pets",
-      "mode": "managed",
-      "type": "time_rotating",
-      "name": "moar_pets",
-      "provider_name": "registry.terraform.io/hashicorp/time",
-      "change": {
-        "actions": [
-          "delete"
-        ],
-        "before": {
-          "day": 25,
-          "hour": 1,
-          "id": "2022-05-25T01:23:59Z",
-          "minute": 23,
-          "month": 5,
-          "rfc3339": "2022-05-25T01:23:59Z",
-          "rotation_days": null,
-          "rotation_hours": null,
-          "rotation_minutes": 1,
-          "rotation_months": null,
-          "rotation_rfc3339": "2022-05-25T01:24:59Z",
-          "rotation_years": null,
-          "second": 59,
-          "triggers": null,
-          "unix": 1653441839,
-          "year": 2022
-        },
-        "after": null,
-        "after_unknown": {},
-        "before_sensitive": {},
-        "after_sensitive": false
-      }
-    }
-  ],
   "resource_changes": [
     {
       "address": "random_integer.pet_length",
@@ -158,34 +116,28 @@
           "create"
         ],
         "before": {
-          "id": "3",
-          "keepers": {
-            "rotate": "2022-05-25T01:23:59Z"
-          },
+          "id": "2",
+          "keepers": null,
           "max": 5,
           "min": 2,
-          "result": 3,
+          "result": 2,
           "seed": null
         },
         "after": {
+          "keepers": null,
           "max": 5,
-          "min": 2,
+          "min": 1,
           "seed": null
         },
         "after_unknown": {
           "id": true,
-          "keepers": true,
           "result": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
           [
-            "keepers"
+            "min"
           ]
         ]
       },
@@ -204,33 +156,24 @@
           "create"
         ],
         "before": {
-          "id": "solely-on-hog",
-          "keepers": {
-            "rotate": "2022-05-25T01:23:59Z"
-          },
-          "length": 3,
+          "id": "selected-chimp",
+          "keepers": null,
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after": {
+          "keepers": null,
+          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": true,
-          "length": true
+          "id": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
-          [
-            "keepers"
-          ],
           [
             "length"
           ]
@@ -251,33 +194,24 @@
           "create"
         ],
         "before": {
-          "id": "trivially-more-raven",
-          "keepers": {
-            "rotate": "2022-05-25T01:23:59Z"
-          },
-          "length": 3,
+          "id": "regular-kodiak",
+          "keepers": null,
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after": {
+          "keepers": null,
+          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": true,
-          "length": true
+          "id": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
-          [
-            "keepers"
-          ],
           [
             "length"
           ]
@@ -298,33 +232,24 @@
           "create"
         ],
         "before": {
-          "id": "nationally-unique-mantis",
-          "keepers": {
-            "rotate": "2022-05-25T01:23:59Z"
-          },
-          "length": 3,
+          "id": "fit-crappie",
+          "keepers": null,
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after": {
+          "keepers": null,
+          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": true,
-          "length": true
+          "id": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
-          [
-            "keepers"
-          ],
           [
             "length"
           ]
@@ -345,33 +270,24 @@
           "create"
         ],
         "before": {
-          "id": "entirely-present-leech",
-          "keepers": {
-            "rotate": "2022-05-25T01:23:59Z"
-          },
-          "length": 3,
+          "id": "meet-jaguar",
+          "keepers": null,
+          "length": 2,
           "prefix": null,
           "separator": "-"
         },
         "after": {
+          "keepers": null,
+          "length": 4,
           "prefix": null,
           "separator": "-"
         },
         "after_unknown": {
-          "id": true,
-          "keepers": true,
-          "length": true
+          "id": true
         },
-        "before_sensitive": {
-          "keepers": {}
-        },
-        "after_sensitive": {
-          "keepers": {}
-        },
+        "before_sensitive": {},
+        "after_sensitive": {},
         "replace_paths": [
-          [
-            "keepers"
-          ],
           [
             "length"
           ]
@@ -391,9 +307,9 @@
         ],
         "before": null,
         "after": {
-          "rotation_days": null,
+          "rotation_days": 30,
           "rotation_hours": null,
-          "rotation_minutes": 1,
+          "rotation_minutes": null,
           "rotation_months": null,
           "rotation_years": null,
           "triggers": null
@@ -415,46 +331,10 @@
       }
     }
   ],
-  "output_changes": {
-    "pets": {
-      "actions": [
-        "update"
-      ],
-      "before": [
-        "solely-on-hog",
-        "trivially-more-raven",
-        "nationally-unique-mantis",
-        "entirely-present-leech"
-      ],
-      "after_unknown": true,
-      "before_sensitive": false,
-      "after_sensitive": false
-    }
-  },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.2.1",
+    "terraform_version": "1.5.3",
     "values": {
-      "outputs": {
-        "pets": {
-          "sensitive": false,
-          "value": [
-            "solely-on-hog",
-            "trivially-more-raven",
-            "nationally-unique-mantis",
-            "entirely-present-leech"
-          ],
-          "type": [
-            "tuple",
-            [
-              "string",
-              "string",
-              "string",
-              "string"
-            ]
-          ]
-        }
-      },
       "root_module": {
         "resources": [
           {
@@ -465,21 +345,14 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "3",
-              "keepers": {
-                "rotate": "2022-05-25T01:23:59Z"
-              },
+              "id": "2",
+              "keepers": null,
               "max": 5,
               "min": 2,
-              "result": 3,
+              "result": 2,
               "seed": null
             },
-            "sensitive_values": {
-              "keepers": {}
-            },
-            "depends_on": [
-              "time_rotating.moar_pets"
-            ]
+            "sensitive_values": {}
           },
           {
             "address": "random_pet.rando[0]",
@@ -490,21 +363,13 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "solely-on-hog",
-              "keepers": {
-                "rotate": "2022-05-25T01:23:59Z"
-              },
-              "length": 3,
+              "id": "selected-chimp",
+              "keepers": null,
+              "length": 2,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {
-              "keepers": {}
-            },
-            "depends_on": [
-              "random_integer.pet_length",
-              "time_rotating.moar_pets"
-            ]
+            "sensitive_values": {}
           },
           {
             "address": "random_pet.rando[1]",
@@ -515,21 +380,13 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "trivially-more-raven",
-              "keepers": {
-                "rotate": "2022-05-25T01:23:59Z"
-              },
-              "length": 3,
+              "id": "regular-kodiak",
+              "keepers": null,
+              "length": 2,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {
-              "keepers": {}
-            },
-            "depends_on": [
-              "random_integer.pet_length",
-              "time_rotating.moar_pets"
-            ]
+            "sensitive_values": {}
           },
           {
             "address": "random_pet.rando[2]",
@@ -540,21 +397,13 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "nationally-unique-mantis",
-              "keepers": {
-                "rotate": "2022-05-25T01:23:59Z"
-              },
-              "length": 3,
+              "id": "fit-crappie",
+              "keepers": null,
+              "length": 2,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {
-              "keepers": {}
-            },
-            "depends_on": [
-              "random_integer.pet_length",
-              "time_rotating.moar_pets"
-            ]
+            "sensitive_values": {}
           },
           {
             "address": "random_pet.rando[3]",
@@ -565,21 +414,13 @@
             "provider_name": "registry.terraform.io/hashicorp/random",
             "schema_version": 0,
             "values": {
-              "id": "entirely-present-leech",
-              "keepers": {
-                "rotate": "2022-05-25T01:23:59Z"
-              },
-              "length": 3,
+              "id": "meet-jaguar",
+              "keepers": null,
+              "length": 2,
               "prefix": null,
               "separator": "-"
             },
-            "sensitive_values": {
-              "keepers": {}
-            },
-            "depends_on": [
-              "random_integer.pet_length",
-              "time_rotating.moar_pets"
-            ]
+            "sensitive_values": {}
           }
         ]
       }
@@ -597,15 +438,6 @@
       }
     },
     "root_module": {
-      "outputs": {
-        "pets": {
-          "expression": {
-            "references": [
-              "random_pet.rando"
-            ]
-          }
-        }
-      },
       "resources": [
         {
           "address": "random_integer.pet_length",
@@ -614,17 +446,11 @@
           "name": "pet_length",
           "provider_config_key": "random",
           "expressions": {
-            "keepers": {
-              "references": [
-                "time_rotating.moar_pets.id",
-                "time_rotating.moar_pets"
-              ]
-            },
             "max": {
               "constant_value": 5
             },
             "min": {
-              "constant_value": 2
+              "constant_value": 1
             }
           },
           "schema_version": 0
@@ -636,20 +462,8 @@
           "name": "rando",
           "provider_config_key": "random",
           "expressions": {
-            "keepers": {
-              "references": [
-                "time_rotating.moar_pets.id",
-                "time_rotating.moar_pets"
-              ]
-            },
             "length": {
-              "references": [
-                "random_integer.pet_length.result",
-                "random_integer.pet_length"
-              ]
-            },
-            "separator": {
-              "constant_value": "-"
+              "constant_value": 4
             }
           },
           "schema_version": 0,
@@ -664,8 +478,8 @@
           "name": "moar_pets",
           "provider_config_key": "time",
           "expressions": {
-            "rotation_minutes": {
-              "constant_value": 1
+            "rotation_days": {
+              "constant_value": 30
             }
           },
           "schema_version": 0
@@ -673,22 +487,5 @@
       ]
     }
   },
-  "relevant_attributes": [
-    {
-      "resource": "random_pet.rando",
-      "attribute": []
-    },
-    {
-      "resource": "time_rotating.moar_pets",
-      "attribute": [
-        "id"
-      ]
-    },
-    {
-      "resource": "random_integer.pet_length",
-      "attribute": [
-        "result"
-      ]
-    }
-  ]
+  "timestamp": "2023-07-20T15:11:25Z"
 }


### PR DESCRIPTION
This PR adds in support for the [import block](https://developer.hashicorp.com/terraform/language/import) which was introduced in Terraform 1.5.

Imported resources are shown in a new `N to import` field similar to the CLI and TF cloud output. 

![image](https://github.com/zapier/tfbuddy/assets/14356001/400ef6c2-8fa7-4d44-b071-26248f2d464a)


Additionally, some extra changes are made to make this change possible:

### Dependency Updates

- go-tfe was updated to 1.30.0 to support the new API actions for imported resources
- terraform-json was updated to 0.17.1 to add support for imported resources
- Any dependencies needed by the new versions were updated
- It will be implied that when testing these changes, you will need to use Terraform 1.5.0 or greater to support the import blocks. Older versions may fail when parsing the `import {}` blocks.

### Localdev changes

Localdev changes needed to test the new import fields 

- Added 2 new resources that utilize Terraform's import function
- The `wait-for-ngrok-url` job was relaxed to grep only `ngrok` instead of `ngrok.io` due to the free app using a different DNS suffix (ngrok-free.app) vs (ngrok.io)