### PR TITLE
Pretty up previous TFC runs URLs list via markdown tables instead of just a list of URLs

### DIFF
--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -176,5 +176,4 @@ const OLD_RUN_BLOCK = `
 
 | Run ID | Status |
 | ------ | ------ |
-
 %s`

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -174,6 +174,6 @@ var needToApplyFullWorkSpace = `
 const OLD_RUN_BLOCK = `
 ### Previous TFC URLS
 
-| Run ID | Status |
-| ------ | ------ |
+| Run ID | Status | Created at |
+| ------ | ------ | ---------- |
 %s`

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -173,4 +173,8 @@ var needToApplyFullWorkSpace = `
 
 const OLD_RUN_BLOCK = `
 ### Previous TFC URLS
+
+| Run ID | Status |
+| ------ | ------ |
+
 %s`

--- a/pkg/terraform_plan/templates/plan_output.tpl
+++ b/pkg/terraform_plan/templates/plan_output.tpl
@@ -5,7 +5,7 @@
 {{- end}}
 {{ end }}
 
-:airplane_arriving: <b>Imports:</b> {{.ImportCount}}
+:inbox_tray: <b>Imports:</b> {{.ImportCount}}
 <ul>
 {{- range .Imports}}
     <li><code>{{ . }}</code></li>

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/basic.md
@@ -1,6 +1,6 @@
 
 
-:airplane_arriving: <b>Imports:</b> 0
+:inbox_tray: <b>Imports:</b> 0
 <ul>
 </ul>
 

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/destroy-create.md
@@ -1,6 +1,6 @@
 
 
-:airplane_arriving: <b>Imports:</b> 0
+:inbox_tray: <b>Imports:</b> 0
 <ul>
 </ul>
 

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/import.md
@@ -1,6 +1,6 @@
 
 
-:airplane_arriving: <b>Imports:</b> 1
+:inbox_tray: <b>Imports:</b> 1
 <ul>
     <li><code>random_integer.import</code></li>
 </ul>

--- a/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.md
+++ b/pkg/terraform_plan/testdata/TestPresentPlanChangesAsMarkdown/replace.md
@@ -1,6 +1,6 @@
 
 
-:airplane_arriving: <b>Imports:</b> 0
+:inbox_tray: <b>Imports:</b> 0
 <ul>
 </ul>
 

--- a/pkg/utils/formatter.go
+++ b/pkg/utils/formatter.go
@@ -16,8 +16,8 @@ const (
 
 </summary>
 
-| Run ID | Status |
-| ------ | ------ |`
+| Run ID | Status | Created at |
+| ------ | ------ | ---------- |`
 	URL_RUN_GROUP_SUFFIX  = "</details>"
 	URL_RUN_STATUS_PREFIX = "**Status**: "
 )

--- a/pkg/utils/formatter.go
+++ b/pkg/utils/formatter.go
@@ -14,7 +14,10 @@ const (
 
 ### Previous TFC Urls:
 
-</summary>`
+</summary>
+
+| Run ID | Status |
+| ------ | ------ |`
 	URL_RUN_GROUP_SUFFIX  = "</details>"
 	URL_RUN_STATUS_PREFIX = "**Status**: "
 )

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -93,8 +93,8 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (st
 			runID := runUrlSplit[len(runUrlSplit)-1]
 			runStatus := utils.CaptureSubstring(comment.GetBody(), utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
-				// Example: <tfc url> - ✅ Applied
-				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrlRaw, runStatus))
+				// Example: |[<tfc runID>](<tfc url>)|✅ Applied|2023-08-02 15:41:48.82 +0000 UTC|
+				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|%s|", runID, runUrlRaw, runStatus, comment.CreatedAt))
 			}
 
 			// Github orders comments from earliest -> latest via ID, so we check each comment and take the last match on an "old url" block

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -109,11 +109,10 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (st
 
 			// Github orders comments from earliest -> latest via ID, so we check each comment and take the last match on an "old url" block
 			oldRunBlockTest := utils.CaptureSubstring(comment.GetBody(), utils.URL_RUN_GROUP_PREFIX, utils.URL_RUN_GROUP_SUFFIX)
+			// Add a new line for the first table entry so that markdown tabling can properly begin
+			oldRunBlock = "\n"
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
-			} else {
-				// Add a new line for the first table entry so that markdown tabling can properly begin
-				oldRunBlock = "\n"
 			}
 
 			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && comment.GetID() != int64(rootCommentID) {

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -98,6 +98,7 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (st
 				// We set the ID and URL to the run URL as a fallback (as it was originally scraped)
 				// It'll appear like this in markdown
 				// [https://app.terraform.io/...](https://app.terraform.io/...)
+				log.Warn().Msg("Unable to obtain Terraform cloud run ID. The run URL(s) on the previous comments may be malformed.")
 				runID = runUrl
 				runUrlRaw = runUrl
 			}

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -90,7 +90,17 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (st
 			runUrlRaw := utils.CaptureSubstring(runUrl, "[", "]")
 			runUrlSplit := strings.Split(runUrlRaw, "/")
 			// The run ID is the last part of the run URL, and it looks like run-abcd12345...
-			runID := runUrlSplit[len(runUrlSplit)-1]
+			runID := ""
+			if len(runUrlSplit) > 0 {
+				runID = runUrlSplit[len(runUrlSplit)-1]
+			} else {
+				// If the URL split slice doesn't contain anything for any reason
+				// We set the ID and URL to the run URL as a fallback (as it was originally scraped)
+				// It'll appear like this in markdown
+				// [https://app.terraform.io/...](https://app.terraform.io/...)
+				runID = runUrl
+				runUrlRaw = runUrl
+			}
 			runStatus := utils.CaptureSubstring(comment.GetBody(), utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
 				// Example: |[<tfc runID>](<tfc url>)|✅ Applied|2023-08-02 15:41:48.82 +0000 UTC|

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -102,6 +102,7 @@ func (c *Client) GetOldRunUrls(prID int, fullName string, rootCommentID int) (st
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
 			} else {
+				// Add a new line for the first table entry so that markdown tabling can properly begin
 				oldRunBlock = "\n"
 			}
 

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -146,6 +146,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
 			} else {
+				// Add a new line for the first table entry so that markdown tabling can properly begin.
 				oldRunBlock = "\n"
 			}
 			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && note.ID != rootNoteID {

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -143,6 +143,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 				// We set the ID and URL to the run URL as a fallback (as it was originally scraped)
 				// It'll appear like this in markdown
 				// [https://app.terraform.io/...](https://app.terraform.io/...)
+				log.Warn().Msg("Unable to obtain Terraform cloud run ID. The run URL(s) on the previous comments may be malformed.")
 				runID = runUrl
 				runUrlRaw = runUrl
 			}

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -129,13 +129,15 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 	for _, note := range notes {
 		if note.Author.Username == currentUser.Username {
 			runUrl := utils.CaptureSubstring(note.Body, utils.URL_RUN_PREFIX, utils.URL_RUN_SUFFIX)
+			// We scrape the run URLs from the previous MR comments.
+			// Since they are hyperlinked in markdown format, we need to extract the URL
+			// without the markdown artifacts.
 			runUrlRaw := utils.CaptureSubstring(runUrl, "[", "]")
-			runUrlSplit := strings.Split(runUrl, "/")
-			runID := strings.Replace(runUrlSplit[len(runUrlSplit)-1], ") ", "", 1)
+			runUrlSplit := strings.Split(runUrlRaw, "/")
+			// The run ID is the last part of the run URL, and it looks like run-abcd12345...
+			runID := runUrlSplit[len(runUrlSplit)-1]
 			runStatus := utils.CaptureSubstring(note.Body, utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
-				log.Debug().Msgf("Run ID: %s", runID)
-				log.Debug().Msgf("Run URL Raw: %s", runUrlRaw)
 				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrlRaw, utils.FormatStatus(runStatus)))
 			}
 
@@ -143,6 +145,8 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 			oldRunBlockTest := utils.CaptureSubstring(note.Body, utils.URL_RUN_GROUP_PREFIX, utils.URL_RUN_GROUP_SUFFIX)
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
+			} else {
+				oldRunBlock = "\n"
 			}
 			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && note.ID != rootNoteID {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Msgf("deleting note %d", note.ID)
@@ -156,7 +160,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 
 	// Add new urls into block
 	if len(oldRunUrls) > 0 {
-		return fmt.Sprintf("%s\n%s\n%s\n%s", utils.URL_RUN_GROUP_PREFIX, oldRunBlock, strings.Join(oldRunUrls, "\n"), utils.URL_RUN_GROUP_SUFFIX), nil
+		return fmt.Sprintf("%s%s%s\n%s", utils.URL_RUN_GROUP_PREFIX, oldRunBlock, strings.Join(oldRunUrls, "\n"), utils.URL_RUN_GROUP_SUFFIX), nil
 	}
 	return oldRunBlock, nil
 }

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -153,11 +153,10 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 
 			// Gitlab default sort is order by created by, so take the last match on this
 			oldRunBlockTest := utils.CaptureSubstring(note.Body, utils.URL_RUN_GROUP_PREFIX, utils.URL_RUN_GROUP_SUFFIX)
+			// Add a new line for the first table entry so that markdown tabling can properly begin
+			oldRunBlock = "\n"
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
-			} else {
-				// Add a new line for the first table entry so that markdown tabling can properly begin
-				oldRunBlock = "\n"
 			}
 			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && note.ID != rootNoteID {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Msgf("deleting note %d", note.ID)

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -135,7 +135,17 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 			runUrlRaw := utils.CaptureSubstring(runUrl, "[", "]")
 			runUrlSplit := strings.Split(runUrlRaw, "/")
 			// The run ID is the last part of the run URL, and it looks like run-abcd12345...
-			runID := runUrlSplit[len(runUrlSplit)-1]
+			runID := ""
+			if len(runUrlSplit) > 0 {
+				runID = runUrlSplit[len(runUrlSplit)-1]
+			} else {
+				// If the URL split slice doesn't contain anything for any reason
+				// We set the ID and URL to the run URL as a fallback (as it was originally scraped)
+				// It'll appear like this in markdown
+				// [https://app.terraform.io/...](https://app.terraform.io/...)
+				runID = runUrl
+				runUrlRaw = runUrl
+			}
 			runStatus := utils.CaptureSubstring(note.Body, utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
 				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|%s|", runID, runUrlRaw, utils.FormatStatus(runStatus), note.CreatedAt))

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -129,9 +129,12 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 	for _, note := range notes {
 		if note.Author.Username == currentUser.Username {
 			runUrl := utils.CaptureSubstring(note.Body, utils.URL_RUN_PREFIX, utils.URL_RUN_SUFFIX)
+			// We need to get the Run ID which is the last portion of the run URL
+			runUrlSplit := strings.Split(runUrl, "/")
+			runID := runUrlSplit[len(runUrlSplit)-1]
 			runStatus := utils.CaptureSubstring(note.Body, utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
-				oldRunUrls = append(oldRunUrls, fmt.Sprintf("%s - %s", runUrl, utils.FormatStatus(runStatus)))
+				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrl, utils.FormatStatus(runStatus)))
 			}
 
 			// Gitlab default sort is order by created by, so take the last match on this

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -129,12 +129,14 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 	for _, note := range notes {
 		if note.Author.Username == currentUser.Username {
 			runUrl := utils.CaptureSubstring(note.Body, utils.URL_RUN_PREFIX, utils.URL_RUN_SUFFIX)
-			// We need to get the Run ID which is the last portion of the run URL
+			runUrlRaw := utils.CaptureSubstring(runUrl, "[", "]")
 			runUrlSplit := strings.Split(runUrl, "/")
-			runID := runUrlSplit[len(runUrlSplit)-1]
+			runID := strings.Replace(runUrlSplit[len(runUrlSplit)-1], ") ", "", 1)
 			runStatus := utils.CaptureSubstring(note.Body, utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
-				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrl, utils.FormatStatus(runStatus)))
+				log.Debug().Msgf("Run ID: %s", runID)
+				log.Debug().Msgf("Run URL Raw: %s", runUrlRaw)
+				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrlRaw, utils.FormatStatus(runStatus)))
 			}
 
 			// Gitlab default sort is order by created by, so take the last match on this

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -146,7 +146,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 			if oldRunBlockTest != "" {
 				oldRunBlock = oldRunBlockTest
 			} else {
-				// Add a new line for the first table entry so that markdown tabling can properly begin.
+				// Add a new line for the first table entry so that markdown tabling can properly begin
 				oldRunBlock = "\n"
 			}
 			if os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS") != "" && note.ID != rootNoteID {

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -138,7 +138,7 @@ func (c *GitlabClient) GetOldRunUrls(mrIID int, project string, rootNoteID int) 
 			runID := runUrlSplit[len(runUrlSplit)-1]
 			runStatus := utils.CaptureSubstring(note.Body, utils.URL_RUN_STATUS_PREFIX, utils.URL_RUN_SUFFIX)
 			if runUrl != "" && runStatus != "" {
-				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|", runID, runUrlRaw, utils.FormatStatus(runStatus)))
+				oldRunUrls = append(oldRunUrls, fmt.Sprintf("|[%s](%s)|%s|%s|", runID, runUrlRaw, utils.FormatStatus(runStatus), note.CreatedAt))
 			}
 
 			// Gitlab default sort is order by created by, so take the last match on this


### PR DESCRIPTION
Closes #34 

Updates the placement of the previous TFC run URLs to use a markdown table instead.

Previously, the list looked like this:

![image](https://github.com/zapier/tfbuddy/assets/14356001/393dfbaa-c93b-4dc7-923d-9976a1a5bce3)


Here is the proposed format:

![image](https://github.com/zapier/tfbuddy/assets/14356001/eaf0dc00-b1b1-4c69-b169-04e1dd5e11bd)

Additionally, using tables I added a `Created at` field to show an exact timestamp of when the run was created (based on the MR creation timestamp) to allow for an easier view of when a TF run was made.


And for compatibility with Github, I replaced the airplane_arriving emoji with 📥 as Github doesn't have the airplane arriving emoji.

### Github testing

Unfortunately, I wasn't able to test these changes on Github as it doesn't seem like Github uses the MR run headers that Gitlab does. So while I've tested to make sure Github's functionality wasn't broken by these changes, I wasn't able to verify if the changes I ported from Gitlab also work on Github.

![image](https://github.com/zapier/tfbuddy/assets/14356001/03e431f1-dbab-4c53-84bf-b037bf840a5b)
