### PR TITLE
fix gitlab formatting error

### DIFF
--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -117,7 +117,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 		wsName,
 		rmd.GetAction(),
 		run.Status,
-		runUrl, runUrl,
+		run.ID, runUrl,
 	)
 
 	return extraInfo, topLevelNoteBody, resolveDiscussion


### PR DESCRIPTION
trying to fix problem with GitLab comment formatting

[see here](https://gitlab.com/gitlab-org/gitlab/-/issues/472838#note_2067989367)

1. replace full URL with just a run ID.