### PR TITLE
Cloud 257 Fix Resolving File Paths with a Common Suffix

### DIFF
--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -24,6 +24,12 @@ type ProjectConfig struct {
 	Workspaces []*TFCWorkspace `yaml:"workspaces"`
 }
 
+// Finds the workspace with the deepest matching directory suffix.
+// For example, given workspaces with config "terraform/dev/" and a dir of "dev/",
+// and a filepath directory of "filesystem/terraform/dev/" - "dev" and "terraform/dev/" are both a suffix 
+// we would return the ws for "terraform/dev/"as it is the deepest match.
+// Special case: if a workspace has config "/" and the input dir is ".", that workspace is returned.
+// If no workspace matches, returns nil.
 func (cfg *ProjectConfig) workspaceForDir(dir string) *TFCWorkspace {
 	var longestMatch *TFCWorkspace
 	var longestMatchDepth int

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -43,10 +43,6 @@ func (cfg *ProjectConfig) workspaceForDir(dir string) *TFCWorkspace {
 
 		if (strings.HasSuffix(dir+"/", wsDir) || strings.HasSuffix(dir, wsDir)) {
 			wsDirDepth := len(strings.Split(wsDir, "/"))
-			fmt.Println(dir)
-			fmt.Println(wsDir)
-			fmt.Println(strings.Split(wsDir, "/"))
-			fmt.Println(wsDirDepth)
 			if wsDirDepth > longestMatchDepth {
 				longestMatch = ws
 				longestMatchDepth = wsDirDepth

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -34,12 +34,19 @@ func (cfg *ProjectConfig) workspaceForDir(dir string) *TFCWorkspace {
 			wsDir += "/"
 		}
 
-		if dir == "." && wsDir == "/" {
-			return ws
+		if wsDir == "/" {
+			if dir == "." {
+				return ws
+			}
+			continue
 		}
 
-		if strings.HasSuffix(dir+"/", wsDir) {
+		if (strings.HasSuffix(dir+"/", wsDir) || strings.HasSuffix(dir, wsDir)) {
 			wsDirDepth := len(strings.Split(wsDir, "/"))
+			fmt.Println(dir)
+			fmt.Println(wsDir)
+			fmt.Println(strings.Split(wsDir, "/"))
+			fmt.Println(wsDirDepth)
 			if wsDirDepth > longestMatchDepth {
 				longestMatch = ws
 				longestMatchDepth = wsDirDepth

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -25,22 +25,28 @@ type ProjectConfig struct {
 }
 
 func (cfg *ProjectConfig) workspaceForDir(dir string) *TFCWorkspace {
+	var longestMatch *TFCWorkspace
+	var longestMatchDepth int
+
 	for _, ws := range cfg.Workspaces {
 		wsDir := ws.Dir
 		if !strings.HasSuffix(wsDir, "/") {
 			wsDir += "/"
 		}
 
-		if strings.HasSuffix(dir, wsDir) {
-			return ws
-		} else if wsDir != "/" && strings.HasSuffix(dir+"/", wsDir) {
-			return ws
-		} else if dir == "." && wsDir == "/" {
+		if dir == "." && wsDir == "/" {
 			return ws
 		}
 
+		if strings.HasSuffix(dir+"/", wsDir) {
+			wsDirDepth := len(strings.Split(wsDir, "/"))
+			if wsDirDepth > longestMatchDepth {
+				longestMatch = ws
+				longestMatchDepth = wsDirDepth
+			}
+		}
 	}
-	return nil
+	return longestMatch
 }
 
 func (cfg *ProjectConfig) workspacesForTriggerDir(dir string) []*TFCWorkspace {

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -365,7 +365,7 @@ func TestProjectConfig_triggeredWorkspaces(t *testing.T) {
 			},
 		},
 		{
-			name:    "subdir-and-dir-same-name",
+			name:    "subdir-and-dir-same-name--dir-change",
 			cfgYaml: tfbuddyYamlSubdirAndDirSameName,
 			args: args{
 				modifiedFiles: []string{
@@ -373,7 +373,19 @@ func TestProjectConfig_triggeredWorkspaces(t *testing.T) {
 				},
 			},
 			want: []*TFCWorkspace{
-				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[1],
+				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[0], // "workspaces" workspace
+			},
+		},
+		{
+			name:    "subdir-and-dir-same-name--subdir-change",
+			cfgYaml: tfbuddyYamlSubdirAndDirSameName,
+			args: args{
+				modifiedFiles: []string{
+					"aws/workspaces/main.tf",
+				},
+			},
+			want: []*TFCWorkspace{
+				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[1], // "aws/workspaces" workspace
 			},
 		},
 		{
@@ -721,12 +733,12 @@ workspaces:
 const tfbuddyYamlSubdirAndDirSameName = `
 ---
 workspaces:
-  - name: aws-workspaces
-    organization: foo-corp
-    dir: aws/workspaces
   - name: workspaces
     organization: foo-corp
     dir: workspaces
+  - name: aws-workspaces
+    organization: foo-corp
+    dir: aws/workspaces
 
 `
 

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -365,15 +365,39 @@ func TestProjectConfig_triggeredWorkspaces(t *testing.T) {
 			},
 		},
 		{
-			name:    "subdir-and-dir-same-name--dir-change",
-			cfgYaml: tfbuddyYamlSubdirAndDirSameName,
+			name:    "dir-and-subdir-same-name--dir-change",
+			cfgYaml: tfbuddyYamlDirAndSubdirSameName,
 			args: args{
 				modifiedFiles: []string{
 					"workspaces/main.tf",
 				},
 			},
 			want: []*TFCWorkspace{
-				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[0], // "workspaces" workspace
+				testLoadConfig(t, tfbuddyYamlDirAndSubdirSameName).Workspaces[0], // "workspaces" workspace
+			},
+		},
+		{
+			name:    "dir-and-subdir-same-name--subdir-change",
+			cfgYaml: tfbuddyYamlDirAndSubdirSameName,
+			args: args{
+				modifiedFiles: []string{
+					"aws/workspaces/main.tf",
+				},
+			},
+			want: []*TFCWorkspace{
+				testLoadConfig(t, tfbuddyYamlDirAndSubdirSameName).Workspaces[1], // "aws/workspaces" workspace
+			},
+		},
+		{
+			name:    "subdir-and-dir-same-name--dir-change",
+			cfgYaml: tfbuddyYamlSubdirAndDirSameName,
+			args: args{
+				modifiedFiles: []string{
+					"test2/test3/main.tf",
+				},
+			},
+			want: []*TFCWorkspace{
+				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[1], // "test2/test3" workspace
 			},
 		},
 		{
@@ -381,11 +405,11 @@ func TestProjectConfig_triggeredWorkspaces(t *testing.T) {
 			cfgYaml: tfbuddyYamlSubdirAndDirSameName,
 			args: args{
 				modifiedFiles: []string{
-					"aws/workspaces/main.tf",
+					"test1/test2/test3/main.tf",
 				},
 			},
 			want: []*TFCWorkspace{
-				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[1], // "aws/workspaces" workspace
+				testLoadConfig(t, tfbuddyYamlSubdirAndDirSameName).Workspaces[0], // "test1/test2/test3" workspace
 			},
 		},
 		{
@@ -730,7 +754,7 @@ workspaces:
 
 `
 
-const tfbuddyYamlSubdirAndDirSameName = `
+const tfbuddyYamlDirAndSubdirSameName = `
 ---
 workspaces:
   - name: workspaces
@@ -739,6 +763,18 @@ workspaces:
   - name: aws-workspaces
     organization: foo-corp
     dir: aws/workspaces
+
+`
+
+const tfbuddyYamlSubdirAndDirSameName = `
+---
+workspaces:
+  - name: subdir
+    organization: foo-corp
+    dir: test1/test2/test3
+  - name: dir
+    organization: foo-corp
+    dir: test2/test3
 
 `
 


### PR DESCRIPTION
Improve workspace directory matching logic

Updates the workspaceForDir method to find the most specific (deepest) matching workspace directory instead of returning the first match. This ensures that nested workspace configurations are handled correctly by comparing path depths.

For example, if we have workspaces configured for both "prod/" and "terraform/prod/", this change will ensure that paths under "terraform/prod/" match the more specific workspace configuration irrelevant of config order.