### PR TITLE
Improve testing in pkg/allow_list

### DIFF
--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -15,9 +15,13 @@ func getAllowList(envVar string) []string {
 		allowList := make([]string, 0)
 		for _, p := range allowedParts {
 			prefix := strings.TrimSpace(p)
-			log.Info().Str("prefix", prefix).Msg("adding repo prefix to allow list")
-			allowList = append(allowList, prefix)
-
+			if prefix != "" {
+				log.Info().Str("prefix", prefix).Msg("adding repo prefix to allow list")
+				allowList = append(allowList, prefix)
+			}
+		}
+		if len(allowList) == 0 {
+			return nil
 		}
 		return allowList
 	}

--- a/pkg/allow_list/common_test.go
+++ b/pkg/allow_list/common_test.go
@@ -1,0 +1,87 @@
+package allow_list
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetAllowList(t *testing.T) {
+	const testEnvVar = "TEST_ALLOW_LIST_ENV"
+
+	tests := []struct {
+		name   string
+		envVal string
+		want   []string
+	}{
+		{
+			name:   "multiple values",
+			envVal: "prefix1,prefix2,prefix3",
+			want:   []string{"prefix1", "prefix2", "prefix3"},
+		},
+		{
+			name:   "single value",
+			envVal: "prefix1",
+			want:   []string{"prefix1"},
+		},
+		{
+			name:   "values with spaces",
+			envVal: " prefix1 , prefix2 , prefix3 ",
+			want:   []string{"prefix1", "prefix2", "prefix3"},
+		},
+		{
+			name:   "empty env",
+			envVal: "",
+			want:   nil,
+		},
+		{
+			name:   "only spaces",
+			envVal: "   ",
+			want:   nil,
+		},
+		{
+			name:   "empty strings in list",
+			envVal: "prefix1,,prefix3",
+			want:   []string{"prefix1", "prefix3"},
+		},
+		{
+			name:   "trailing comma",
+			envVal: "prefix1,prefix2,",
+			want:   []string{"prefix1", "prefix2"},
+		},
+		{
+			name:   "leading comma",
+			envVal: ",prefix1,prefix2",
+			want:   []string{"prefix1", "prefix2"},
+		},
+		{
+			name:   "multiple consecutive commas",
+			envVal: "prefix1,,,prefix2",
+			want:   []string{"prefix1", "prefix2"},
+		},
+		{
+			name:   "only commas",
+			envVal: ",,,",
+			want:   nil,
+		},
+		{
+			name:   "values with forward slashes",
+			envVal: "zapier/,github/org,gitlab/project",
+			want:   []string{"zapier/", "github/org", "gitlab/project"},
+		},
+		{
+			name:   "values with special characters",
+			envVal: "org-name,project_name,repo.name,user@domain",
+			want:   []string{"org-name", "project_name", "repo.name", "user@domain"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(testEnvVar, tt.envVal)
+
+			if got := getAllowList(testEnvVar); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllowList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/allow_list/github_test.go
+++ b/pkg/allow_list/github_test.go
@@ -1,0 +1,116 @@
+package allow_list
+
+import (
+	"testing"
+)
+
+func TestIsGithubRepoAllowed(t *testing.T) {
+	type args struct {
+		fullName string
+		allowEnv string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "org/repo_allowed",
+			args: args{
+				fullName: "org/repo",
+				allowEnv: "org,other_org",
+			},
+			want: true,
+		},
+		{
+			name: "org/other_repo_allowed",
+			args: args{
+				fullName: "org/other_repo",
+				allowEnv: "org,other_org",
+			},
+			want: true,
+		},
+		{
+			name: "different_org/repo_denied",
+			args: args{
+				fullName: "different_org/repo",
+				allowEnv: "org,other_org",
+			},
+			want: false,
+		},
+		{
+			name: "env not set",
+			args: args{
+				fullName: "org/repo",
+				allowEnv: "",
+			},
+			want: false,
+		},
+		{
+			name: "env single space",
+			args: args{
+				fullName: "org/repo",
+				allowEnv: " ",
+			},
+			want: false,
+		},
+		{
+			name: "specific repo allowed",
+			args: args{
+				fullName: "org/specific-repo",
+				allowEnv: "org/specific-repo,other_org",
+			},
+			want: true,
+		},
+		{
+			name: "repo not in specific list",
+			args: args{
+				fullName: "org/other-repo",
+				allowEnv: "org/specific-repo,other_org/repo",
+			},
+			want: false,
+		},
+		{
+			name: "partial match allowed with prefix",
+			args: args{
+				fullName: "orgprefix/repo",
+				allowEnv: "org,other_org",
+			},
+			want: true,
+		},
+		{
+			name: "spaces in allow list",
+			args: args{
+				fullName: "org/repo",
+				allowEnv: "org, other_org",
+			},
+			want: true,
+		},
+		{
+			name: "trailing spaces",
+			args: args{
+				fullName: "other_org/repo",
+				allowEnv: "org,other_org ",
+			},
+			want: true,
+		},
+		{
+			name: "case sensitivity",
+			args: args{
+				fullName: "Org/Repo",
+				allowEnv: "org",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(githubRepoAllowListEnv, tt.args.allowEnv)
+
+			if got := IsGithubRepoAllowed(tt.args.fullName); got != tt.want {
+				t.Errorf("IsGithubRepoAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changes:
- Switching to using t.Setenv in tests - it calls a defer to unset in each test.
- Updated logic to skip empty strings, and return nil for an empty slice. 

---

**Testing**

Before:
```
github.com/zapier/tfbuddy/pkg/allow_list/common.go:10:  getAllowList            100.0%
github.com/zapier/tfbuddy/pkg/allow_list/github.go:11:  IsGithubRepoAllowed     0.0%
github.com/zapier/tfbuddy/pkg/allow_list/gitlab.go:12:  IsGitlabProjectAllowed  100.0%
total:                                                  (statements)            68.8%
```

After:
```
github.com/zapier/tfbuddy/pkg/allow_list/common.go:10:  getAllowList            100.0%
github.com/zapier/tfbuddy/pkg/allow_list/github.go:11:  IsGithubRepoAllowed     100.0%
github.com/zapier/tfbuddy/pkg/allow_list/gitlab.go:12:  IsGitlabProjectAllowed  100.0%
total:                                                  (statements)            100.0%
```