### PR TITLE
CLOUD-1653 Fix modified workspace discovery

### DIFF
--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -128,14 +128,25 @@ func hasChangesForWorkspace(ws *TFCWorkspace, modifiedFiles []string) bool {
 			}
 		}
 
-		// Check if file's directory matches any triggerDir (glob match)
+		// Check if file matches any triggerDir (glob match).
+		// Match against both the directory and the full file path so that
+		// patterns like "staging/*.tf" (file-level) and "modules/**" (directory-level)
+		// both work correctly.
 		for _, td := range ws.TriggerDirs {
-			match, err := doublestar.Match(td, fileDir)
+			dirMatch, err := doublestar.Match(td, fileDir)
 			if err != nil {
 				log.Warn().Err(err).Str("triggerDir", td).Str("fileDir", fileDir).Msg("invalid triggerDir glob pattern, treating as match to be safe")
 				return true
 			}
-			if match {
+			if dirMatch {
+				return true
+			}
+			fileMatch, err := doublestar.Match(td, mf)
+			if err != nil {
+				log.Warn().Err(err).Str("triggerDir", td).Str("file", mf).Msg("invalid triggerDir glob pattern, treating as match to be safe")
+				return true
+			}
+			if fileMatch {
 				return true
 			}
 		}

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -130,7 +130,12 @@ func hasChangesForWorkspace(ws *TFCWorkspace, modifiedFiles []string) bool {
 
 		// Check if file's directory matches any triggerDir (glob match)
 		for _, td := range ws.TriggerDirs {
-			if match, _ := doublestar.Match(td, fileDir); match {
+			match, err := doublestar.Match(td, fileDir)
+			if err != nil {
+				log.Warn().Err(err).Str("triggerDir", td).Str("fileDir", fileDir).Msg("invalid triggerDir glob pattern, treating as match to be safe")
+				return true
+			}
+			if match {
 				return true
 			}
 		}

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -100,6 +100,44 @@ func (cfg *ProjectConfig) triggeredWorkspaces(modifiedFiles []string) []*TFCWork
 	return triggered
 }
 
+// hasChangesForWorkspace checks if any of the given modified files fall within
+// a workspace's Dir (prefix match) or match its TriggerDirs (glob match).
+// This is used for divergence detection: checking whether a workspace's relevant
+// directories have changed on the target branch.
+func hasChangesForWorkspace(ws *TFCWorkspace, modifiedFiles []string) bool {
+	wsDir := ws.Dir
+	if wsDir != "" && !strings.HasSuffix(wsDir, "/") {
+		wsDir += "/"
+	}
+
+	// Root workspace (empty or "/" dir) matches files directly in the root directory
+	isRootWS := wsDir == "" || wsDir == "/"
+
+	for _, mf := range modifiedFiles {
+		fileDir := path.Dir(mf)
+
+		if isRootWS {
+			// Root workspace only matches root-level files (dir == ".")
+			if fileDir == "." {
+				return true
+			}
+		} else {
+			// Check if file is within workspace's Dir (prefix match)
+			if strings.HasPrefix(mf, wsDir) {
+				return true
+			}
+		}
+
+		// Check if file's directory matches any triggerDir (glob match)
+		for _, td := range ws.TriggerDirs {
+			if match, _ := doublestar.Match(td, fileDir); match {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type TFCWorkspace struct {
 	Name         string   `yaml:"name" validate:"empty=false"`
 	Organization string   `yaml:"organization" validate:"empty=false"`

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -734,6 +734,36 @@ func TestHasChangesForWorkspace(t *testing.T) {
 			modifiedFiles: []string{"services/a/production/global-us-east-1/main.tf"},
 			want:          true,
 		},
+		{
+			name: "file-level glob triggerDir matches tf file",
+			ws: &TFCWorkspace{
+				Name:        "events-infra-staging",
+				Dir:         "staging/global-us-east-1/",
+				TriggerDirs: []string{"staging/*.tf"},
+			},
+			modifiedFiles: []string{"staging/main.tf"},
+			want:          true,
+		},
+		{
+			name: "file-level glob triggerDir no match for non-tf file",
+			ws: &TFCWorkspace{
+				Name:        "events-infra-staging",
+				Dir:         "staging/global-us-east-1/",
+				TriggerDirs: []string{"staging/*.tf"},
+			},
+			modifiedFiles: []string{"staging/README.md"},
+			want:          false,
+		},
+		{
+			name: "doublestar triggerDir matches nested file",
+			ws: &TFCWorkspace{
+				Name:        "test-ws",
+				Dir:         "terraform/dev/",
+				TriggerDirs: []string{"modules/**"},
+			},
+			modifiedFiles: []string{"modules/database/rds/main.tf"},
+			want:          true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -617,6 +617,133 @@ func Test_loadProjectConfig(t *testing.T) {
 	}
 }
 
+func TestHasChangesForWorkspace(t *testing.T) {
+	tests := []struct {
+		name          string
+		ws            *TFCWorkspace
+		modifiedFiles []string
+		want          bool
+	}{
+		{
+			name: "file in workspace dir",
+			ws: &TFCWorkspace{
+				Name: "service-a-prod",
+				Dir:  "services/a/production/global-us-east-1/",
+			},
+			modifiedFiles: []string{"services/a/production/global-us-east-1/main.tf"},
+			want:          true,
+		},
+		{
+			name: "file matching triggerDir",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{"services/a/production/variables.tf"},
+			want:          true,
+		},
+		{
+			name: "file in different service dir - no match",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{"services/b/production/global-us-east-1/main.tf"},
+			want:          false,
+		},
+		{
+			name: "file in different service triggerDir - no match",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{"services/b/production/variables.tf"},
+			want:          false,
+		},
+		{
+			name: "root file - no match",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{"CODEOWNERS"},
+			want:          false,
+		},
+		{
+			name: "multiple files - one matches dir",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{
+				"CODEOWNERS",
+				"services/b/staging/main.tf",
+				"services/a/production/global-us-east-1/main.tf",
+			},
+			want: true,
+		},
+		{
+			name: "multiple files - one matches triggerDir",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{
+				"CODEOWNERS",
+				"services/b/staging/main.tf",
+				"services/a/production/variables.tf",
+			},
+			want: true,
+		},
+		{
+			name: "multiple unrelated files - no match",
+			ws: &TFCWorkspace{
+				Name:        "service-a-prod",
+				Dir:         "services/a/production/global-us-east-1/",
+				TriggerDirs: []string{"services/a/production"},
+			},
+			modifiedFiles: []string{
+				"CODEOWNERS",
+				"services/b/staging/main.tf",
+				"services/c/production/variables.tf",
+			},
+			want: false,
+		},
+		{
+			name: "empty dir workspace with triggerDir match",
+			ws: &TFCWorkspace{
+				Name:        "root-ws",
+				Dir:         "",
+				TriggerDirs: []string{"modules/**"},
+			},
+			modifiedFiles: []string{"modules/shared/main.tf"},
+			want:          true,
+		},
+		{
+			name: "dir without trailing slash",
+			ws: &TFCWorkspace{
+				Name: "service-a-prod",
+				Dir:  "services/a/production/global-us-east-1",
+			},
+			modifiedFiles: []string{"services/a/production/global-us-east-1/main.tf"},
+			want:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasChangesForWorkspace(tt.ws, tt.modifiedFiles); got != tt.want {
+				t.Errorf("hasChangesForWorkspace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func testLoadConfig(t *testing.T, yaml string) *ProjectConfig {
 	pc, err := loadProjectConfig([]byte(yaml))
 	if err != nil {

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -305,8 +305,8 @@ type TriggeredTFCWorkspaces struct {
 	Executed []string
 }
 
-func (t *TFCTrigger) getModifiedWorkspaceBetweenMergeBaseTargetBranch(ctx context.Context, mr vcs.MR, repo vcs.GitRepo) (map[string]struct{}, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getModifiedWorkspaceBetweenMergeBaseTargetBranch")
+func (t *TFCTrigger) getModifiedWorkspacesOnTargetBranch(ctx context.Context, mr vcs.MR, repo vcs.GitRepo, triggeredWorkspaces []*TFCWorkspace) (map[string]struct{}, error) {
+	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getModifiedWorkspacesOnTargetBranch")
 	defer span.End()
 
 	modifiedWSMap := make(map[string]struct{}, 0)
@@ -330,14 +330,15 @@ func (t *TFCTrigger) getModifiedWorkspaceBetweenMergeBaseTargetBranch(ctx contex
 	log.Debug().Msgf("%+v files modified between merge base and target branch (%s)", targetModifiedFiles, mr.GetTargetBranch())
 	// if there's no modified files we can assume it's safe to continue
 	if len(targetModifiedFiles) > 0 {
-		// use the same logic to find triggeredWorkspaces based on files modified between when the source branch was
-		// forked and the current HEAD of the target branch
-		targetBranchWorkspaces, err := t.getTriggeredWorkspaces(ctx, targetModifiedFiles)
-		if err != nil {
-			return modifiedWSMap, fmt.Errorf("could not find modified workspaces for target branch. %w", err)
-		}
-		for _, ws := range targetBranchWorkspaces {
-			modifiedWSMap[ws.Name] = struct{}{}
+		// For each workspace the MR triggers, check if any files changed on the
+		// target branch fall within that workspace's Dir (prefix match) or match
+		// its TriggerDirs (glob match). This avoids the suffix-based matching in
+		// workspaceForDir which can produce false positives across services.
+		for _, ws := range triggeredWorkspaces {
+			if hasChangesForWorkspace(ws, targetModifiedFiles) {
+				log.Debug().Str("ws", ws.Name).Str("dir", ws.Dir).Msg("workspace has changes on target branch")
+				modifiedWSMap[ws.Name] = struct{}{}
+			}
 		}
 	}
 	return modifiedWSMap, err
@@ -395,7 +396,7 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 		}
 		defer os.Remove(repo.GetLocalDirectory())
 
-		modifiedWSMap, err := t.getModifiedWorkspaceBetweenMergeBaseTargetBranch(ctx, mr, repo)
+		modifiedWSMap, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
 		if err != nil {
 			err = t.postUpdate(ctx, ":warning: Could not identify modified workspaces on target branch. Please review the plan carefully for unrelated changes.")
 			if err != nil {
@@ -413,11 +414,10 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 				continue
 			}
 			if _, ok := modifiedWSMap[cfgWS.Name]; ok {
-				//found in modified target
-				log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because it is modified in the target branch.")
+				log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Msg("Blocking workspace: directory modified on target branch.")
 				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
 					Name:  cfgWS.Name,
-					Error: "Ignoring workspace, because it is modified in the target branch. Please rebase/merge target branch to resolve this.",
+					Error: fmt.Sprintf("Blocked: directory '%s' has been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir),
 				})
 				continue
 			}

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -414,10 +414,10 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 				continue
 			}
 			if _, ok := modifiedWSMap[cfgWS.Name]; ok {
-				log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Msg("Blocking workspace: directory modified on target branch.")
+				log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Strs("triggerDirs", cfgWS.TriggerDirs).Msg("Blocking workspace: relevant paths modified on target branch.")
 				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
 					Name:  cfgWS.Name,
-					Error: fmt.Sprintf("Blocked: directory '%s' has been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir),
+					Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs),
 				})
 				continue
 			}

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -500,7 +501,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 		t.Fatal("expected log message not nil")
 		return
 	}
-	lastEntry.ExpMsg("Ignoring workspace, because it is modified in the target branch.")
+	lastEntry.ExpMsg("Blocking workspace: directory modified on target branch.")
 
 	if len(triggeredWS.Errored) == 0 {
 		t.Fatal("expected  failed workspaces")
@@ -511,7 +512,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 	if triggeredWS.Errored[0].Name != mocks.TF_WORKSPACE_NAME {
 		t.Fatal("unexpected workspace", triggeredWS.Errored[0].Name)
 	}
-	if triggeredWS.Errored[0].Error != "Ignoring workspace, because it is modified in the target branch. Please rebase/merge target branch to resolve this." {
+	if !strings.Contains(triggeredWS.Errored[0].Error, "has been modified on the target branch since this branch diverged") {
 		t.Fatal("unexpected error", triggeredWS.Errored[0].Error)
 	}
 }
@@ -803,5 +804,75 @@ func TestAutoMerge_Globally_Disabled(t *testing.T) {
 	}
 	if triggeredWS.Executed[0] != "service-tfbuddy" {
 		t.Fatal("expected workspace", triggeredWS.Errored[0].Name)
+	}
+}
+
+// TestTFCEvents_ApplyNotBlockedByDifferentServiceChanges verifies that changes
+// on the target branch in a different service directory do not block applies for
+// unrelated workspaces.
+func TestTFCEvents_ApplyNotBlockedByDifferentServiceChanges(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{
+		ProjectConfig: &tfc_trigger.ProjectConfig{
+			Workspaces: []*tfc_trigger.TFCWorkspace{{
+				Name:         "services-tracking-api-prod",
+				Organization: "zapier-test",
+				Mode:         "apply-before-merge",
+				Dir:          "services/tracking-api/production/global-us-east-1/",
+				TriggerDirs:  []string{"services/tracking-api/production"},
+			}}},
+	}, t)
+
+	// MR modifies files in the workspace dir
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return([]string{"services/tracking-api/production/global-us-east-1/main.tf"}, nil).AnyTimes()
+	// Target branch has changes in a DIFFERENT service
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, testSuite.MetaData.TargetBranch).Return([]string{
+		"services/promo/staging/main-us-west-2/main.tf",
+		"services/litellm/staging/global-us-east-1/variables.tf",
+		"CODEOWNERS",
+	}, nil).AnyTimes()
+
+	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).Return(&tfe.Run{
+		ID: "101",
+		Workspace: &tfe.Workspace{Name: "services-tracking-api-prod",
+			Organization: &tfe.Organization{Name: "zapier-test"},
+		},
+		ConfigurationVersion: &tfe.ConfigurationVersion{Speculative: true}}, nil)
+
+	mockRunPollingTask := mocks.NewMockRunPollingTask(mockCtrl)
+	mockRunPollingTask.EXPECT().Schedule(gomock.Any())
+	testSuite.MockStreamClient.EXPECT().NewTFRunPollingTask(gomock.Any(), time.Second*1).Return(mockRunPollingTask)
+
+	testSuite.InitTestSuite()
+
+	testLogger := zltest.New(t)
+	log.Logger = log.Logger.Output(testLogger)
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if len(triggeredWS.Errored) != 0 {
+		t.Fatalf("expected no failed workspaces, got: %v", triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) == 0 {
+		t.Fatal("expected successful triggers")
+	}
+	if triggeredWS.Executed[0] != "services-tracking-api-prod" {
+		t.Fatal("unexpected workspace", triggeredWS.Executed[0])
 	}
 }

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -501,7 +501,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 		t.Fatal("expected log message not nil")
 		return
 	}
-	lastEntry.ExpMsg("Blocking workspace: directory modified on target branch.")
+	lastEntry.ExpMsg("Blocking workspace: relevant paths modified on target branch.")
 
 	if len(triggeredWS.Errored) == 0 {
 		t.Fatal("expected  failed workspaces")
@@ -512,7 +512,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 	if triggeredWS.Errored[0].Name != mocks.TF_WORKSPACE_NAME {
 		t.Fatal("unexpected workspace", triggeredWS.Errored[0].Name)
 	}
-	if !strings.Contains(triggeredWS.Errored[0].Error, "has been modified on the target branch since this branch diverged") {
+	if !strings.Contains(triggeredWS.Errored[0].Error, "have been modified on the target branch since this branch diverged") {
 		t.Fatal("unexpected error", triggeredWS.Errored[0].Error)
 	}
 }


### PR DESCRIPTION
Bug: 
- tfbuddy's divergence check used suffix-based directory matching (workspaceForDir) to map files changed on main to workspaces. This produce false positives across services in a monorepo — changes to completely unrelated services on main incorrectly block plan/apply for other workspaces.

Fix: 
- Replaced the suffix-based "files → workspace lookup" with a direct per-workspace check using prefix matching on the workspace's dir and glob matching on its triggerDirs. Now only changes within a workspace's own directories on main will block it.