### PR TITLE
CLOUD-933 Fix stale workspace lock cleanup and add auto-recovery

### DIFF
--- a/pkg/mocks/mock_vcs.go
+++ b/pkg/mocks/mock_vcs.go
@@ -526,6 +526,20 @@ func (mr *MockDetailedMRMockRecorder) GetAuthor() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthor", reflect.TypeOf((*MockDetailedMR)(nil).GetAuthor))
 }
 
+// GetState mocks base method.
+func (m *MockDetailedMR) GetState() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetState")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetState indicates an expected call of GetState.
+func (mr *MockDetailedMRMockRecorder) GetState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockDetailedMR)(nil).GetState))
+}
+
 // GetInternalID mocks base method.
 func (m *MockDetailedMR) GetInternalID() int {
 	m.ctrl.T.Helper()

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -579,6 +579,11 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	if isApply {
 		lockingMR := t.getLockingMR(ctx, ws.ID)
 		if ws.Locked {
+			// Surface the tag-based locking MR too if we have one, so the user
+			// has something actionable to investigate alongside the TFC lock.
+			if lockingMR != "" {
+				return fmt.Errorf("refusing to Apply changes to a locked workspace (also tagged by MR %s). %w", lockingMR, err)
+			}
 			return fmt.Errorf("refusing to Apply changes to a locked workspace. %w", err)
 		} else if lockingMR != "" {
 			// Check if locking MR is already merged/closed (stale lock)
@@ -592,11 +597,11 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 							Msg("auto-cleaning stale lock from merged/closed MR")
 						tag := fmt.Sprintf("%s-%s", tfPrefix, lockingMR)
 						if removeErr := t.tfc.RemoveTagsByQuery(ctx, ws.ID, tag); removeErr != nil {
-							return fmt.Errorf("failed to auto-clean stale lock tag from MR %s: %w", lockingMR, removeErr)
+							return fmt.Errorf("failed to auto-clean stale lock tag from MR %s: %w", lockingMRDetails.GetWebURL(), removeErr)
 						}
 						// Stale lock removed — fall through to acquire lock for current MR
 					} else {
-						return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
+						return fmt.Errorf("workspace is locked by another MR! %s", lockingMRDetails.GetWebURL())
 					}
 				} else {
 					return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -465,6 +466,7 @@ func (t *TFCTrigger) TriggerCleanupEvent(ctx context.Context) error {
 			cfgWS.Name)
 		if err != nil {
 			t.handleError(ctx, err, "error getting workspace")
+			continue
 		}
 		tags, err := t.tfc.GetTagsByQuery(ctx,
 			ws.ID,
@@ -472,6 +474,7 @@ func (t *TFCTrigger) TriggerCleanupEvent(ctx context.Context) error {
 		)
 		if err != nil {
 			t.handleError(ctx, err, "error getting tags")
+			continue
 		}
 		if len(tags) != 0 {
 			err = t.tfc.RemoveTagsByQuery(ctx, ws.ID, tag)
@@ -541,6 +544,12 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 		if err != nil {
 			return fmt.Errorf("error modifying the TFC lock on the workspace. %w", err)
 		}
+		// On unlock, also remove any tfbuddylock tags for this workspace
+		if t.GetAction() == UnlockAction {
+			if removeErr := t.tfc.RemoveTagsByQuery(ctx, ws.ID, tfPrefix); removeErr != nil {
+				log.Warn().Err(removeErr).Str("workspace", wsName).Msg("failed to remove tfbuddylock tags during unlock")
+			}
+		}
 		_, err := t.gl.CreateMergeRequestDiscussion(ctx, mr.GetInternalID(),
 			t.GetProjectNameWithNamespace(),
 			fmt.Sprintf("Successfully %sed Workspace `%s/%s`", t.GetAction(), org, wsName),
@@ -570,7 +579,29 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 		if ws.Locked {
 			return fmt.Errorf("refusing to Apply changes to a locked workspace. %w", err)
 		} else if lockingMR != "" {
-			return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
+			// Check if locking MR is already merged/closed (stale lock)
+			lockingMRIID, convErr := strconv.Atoi(lockingMR)
+			if convErr == nil {
+				lockingMRDetails, mrErr := t.gl.GetMergeRequest(ctx, lockingMRIID, t.GetProjectNameWithNamespace())
+				if mrErr == nil {
+					state := lockingMRDetails.GetState()
+					if state == "merged" || state == "closed" {
+						log.Warn().Str("workspace", ws.ID).Str("lockingMR", lockingMR).Str("state", state).
+							Msg("auto-cleaning stale lock from merged/closed MR")
+						tag := fmt.Sprintf("%s-%s", tfPrefix, lockingMR)
+						if removeErr := t.tfc.RemoveTagsByQuery(ctx, ws.ID, tag); removeErr != nil {
+							log.Error().Err(removeErr).Msg("failed to auto-clean stale lock tag")
+						}
+						// Fall through to acquire lock for current MR
+					} else {
+						return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
+					}
+				} else {
+					return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
+				}
+			} else {
+				return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
+			}
 		} else {
 			err = t.tfc.AddTags(ctx,
 				ws.ID,

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -541,7 +541,9 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	// the context in the repo isn't necessary
 	if t.GetAction() == LockAction || t.GetAction() == UnlockAction {
 		err = t.LockUnlockWorkspace(ws, mr, t.GetAction() == LockAction)
-		if err != nil {
+		// For unlock, treat ErrWorkspaceUnlocked as non-fatal so we still
+		// clean up stale tfbuddylock-* tags even when the TFC lock is already released.
+		if err != nil && !(t.GetAction() == UnlockAction && errors.Is(err, ErrWorkspaceUnlocked)) {
 			return fmt.Errorf("error modifying the TFC lock on the workspace. %w", err)
 		}
 		// On unlock, also remove any tfbuddylock tags for this workspace
@@ -590,9 +592,9 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 							Msg("auto-cleaning stale lock from merged/closed MR")
 						tag := fmt.Sprintf("%s-%s", tfPrefix, lockingMR)
 						if removeErr := t.tfc.RemoveTagsByQuery(ctx, ws.ID, tag); removeErr != nil {
-							log.Error().Err(removeErr).Msg("failed to auto-clean stale lock tag")
+							return fmt.Errorf("failed to auto-clean stale lock tag from MR %s: %w", lockingMR, removeErr)
 						}
-						// Fall through to acquire lock for current MR
+						// Stale lock removed — fall through to acquire lock for current MR
 					} else {
 						return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
 					}
@@ -602,15 +604,15 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 			} else {
 				return fmt.Errorf("workspace is locked by another MR! %s", lockingMR)
 			}
-		} else {
-			err = t.tfc.AddTags(ctx,
-				ws.ID,
-				tfPrefix,
-				fmt.Sprintf("%d", t.GetMergeRequestIID()),
-			)
-			if err != nil {
-				return fmt.Errorf("error adding tags to workspace. %w", err)
-			}
+		}
+		// Acquire the tag-based lock for the current MR
+		err = t.tfc.AddTags(ctx,
+			ws.ID,
+			tfPrefix,
+			fmt.Sprintf("%d", t.GetMergeRequestIID()),
+		)
+		if err != nil {
+			return fmt.Errorf("error adding tags to workspace. %w", err)
 		}
 	}
 	// create a new Merge Request discussion thread where status updates will be nested

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -876,3 +876,340 @@ func TestTFCEvents_ApplyNotBlockedByDifferentServiceChanges(t *testing.T) {
 		t.Fatal("unexpected workspace", triggeredWS.Executed[0])
 	}
 }
+
+// TestTFCEvents_StaleLock_MergedMR_AutoCleans verifies that when a workspace is
+// locked by a tfbuddylock-* tag from an MR that is already merged, the stale
+// tag is auto-cleaned and the current MR is allowed to proceed (and acquires
+// its own lock tag).
+func TestTFCEvents_StaleLock_MergedMR_AutoCleans(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// Workspace is locked by MR 99 via tag
+	testSuite.MockApiClient.EXPECT().GetTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock").Return([]string{"tfbuddylock-99"}, nil)
+
+	// Locking MR 99 is already merged
+	mockLockingMR := mocks.NewMockDetailedMR(mockCtrl)
+	mockLockingMR.EXPECT().GetState().Return("merged")
+	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), 99, testSuite.MetaData.ProjectNameNS).Return(mockLockingMR, nil)
+
+	// Stale tag is auto-removed, then current MR (101) acquires its lock tag
+	testSuite.MockApiClient.EXPECT().RemoveTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock-99").Return(nil)
+	testSuite.MockApiClient.EXPECT().AddTags(gomock.Any(), gomock.Any(), "tfbuddylock", "101").Return(nil)
+
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).Return(&tfe.Run{
+		ID: "101",
+		Workspace: &tfe.Workspace{Name: "service-tfbuddy",
+			Organization: &tfe.Organization{Name: "zapier-test"},
+		},
+		ConfigurationVersion: &tfe.ConfigurationVersion{Speculative: false}}, nil)
+	testSuite.MockStreamClient.EXPECT().AddRunMeta(gomock.Any())
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(triggeredWS.Errored) != 0 {
+		t.Fatalf("expected no failed workspaces, got: %v", triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) != 1 {
+		t.Fatal("expected successful apply after stale-lock auto-clean")
+	}
+
+}
+
+// TestTFCEvents_StaleLock_OpenMR_Rejects verifies that when a workspace is
+// locked by an MR that is still open, the apply is rejected (no auto-clean).
+func TestTFCEvents_StaleLock_OpenMR_Rejects(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// Workspace is locked by MR 99 via tag
+	testSuite.MockApiClient.EXPECT().GetTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock").Return([]string{"tfbuddylock-99"}, nil)
+
+	// Locking MR 99 is still open — no auto-clean should happen
+	mockLockingMR := mocks.NewMockDetailedMR(mockCtrl)
+	mockLockingMR.EXPECT().GetState().Return("opened")
+	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), 99, testSuite.MetaData.ProjectNameNS).Return(mockLockingMR, nil)
+
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(triggeredWS.Errored) != 1 {
+		t.Fatalf("expected 1 errored workspace, got: %d", len(triggeredWS.Errored))
+	}
+	if !strings.Contains(triggeredWS.Errored[0].Error, "workspace is locked by another MR! 99") {
+		t.Fatalf("expected locked-by-MR error, got: %s", triggeredWS.Errored[0].Error)
+	}
+}
+
+// TestTFCEvents_StaleLock_RemovalFailure_Errors verifies that if the stale tag
+// removal fails, the apply is aborted with an error (rather than proceeding
+// without a clean lock state).
+func TestTFCEvents_StaleLock_RemovalFailure_Errors(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	testSuite.MockApiClient.EXPECT().GetTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock").Return([]string{"tfbuddylock-99"}, nil)
+
+	mockLockingMR := mocks.NewMockDetailedMR(mockCtrl)
+	mockLockingMR.EXPECT().GetState().Return("merged")
+	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), 99, testSuite.MetaData.ProjectNameNS).Return(mockLockingMR, nil)
+
+	// Tag removal fails → apply should abort with error
+	testSuite.MockApiClient.EXPECT().RemoveTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock-99").Return(fmt.Errorf("tfc api blip"))
+
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(triggeredWS.Errored) != 1 {
+		t.Fatalf("expected 1 errored workspace, got: %d", len(triggeredWS.Errored))
+	}
+	if !strings.Contains(triggeredWS.Errored[0].Error, "failed to auto-clean stale lock tag from MR 99") {
+		t.Fatalf("expected stale-lock cleanup error, got: %s", triggeredWS.Errored[0].Error)
+	}
+}
+
+// TestTFCEvents_UnlockRemovesTags verifies that running `tfc unlock` both
+// releases the TFC native lock AND removes any lingering tfbuddylock-* tags
+// from the workspace.
+func TestTFCEvents_UnlockRemovesTags(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// Native lock is currently held; unlocking it should succeed
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", "service-tfbuddy").Return(&tfe.Workspace{ID: "service-tfbuddy", Locked: true}, nil)
+	testSuite.MockApiClient.EXPECT().LockUnlockWorkspace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil)
+
+	// LockUnlockWorkspace wrapper formats a reason string using MR author/URL
+	mockAuthor := mocks.NewMockMRAuthor(mockCtrl)
+	mockAuthor.EXPECT().GetUsername().Return("tester").AnyTimes()
+	testSuite.MockGitMR.EXPECT().GetAuthor().Return(mockAuthor).AnyTimes()
+	testSuite.MockGitMR.EXPECT().GetWebURL().Return("https://gitlab.com/zapier/tfbuddy/-/merge_requests/101").AnyTimes()
+
+	// tfbuddylock tags should also be cleared on unlock
+	testSuite.MockApiClient.EXPECT().RemoveTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock").Return(nil)
+
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(
+		gomock.Any(),
+		testSuite.MetaData.MRIID,
+		testSuite.MetaData.ProjectNameNS,
+		"Successfully unlocked Workspace `zapier-test/service-tfbuddy`",
+	).Return(testSuite.MockGitDisc, nil)
+
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.UnlockAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+		Workspace:                "service-tfbuddy",
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(triggeredWS.Errored) != 0 {
+		t.Fatalf("expected no errored workspaces, got: %v", triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) != 1 {
+		t.Fatal("expected successful unlock trigger")
+	}
+}
+
+// TestTriggerCleanupEvent_ContinuesOnMissingWorkspace verifies that if one
+// workspace in the .tfbuddy.yaml config no longer exists in TFC, the cleanup
+// loop skips it and still removes the lock tag from the remaining workspaces
+// (rather than crashing with a nil pointer dereference on the missing ws).
+func TestTriggerCleanupEvent_ContinuesOnMissingWorkspace(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{
+			{Name: "deleted-ws", Organization: "zapier-test", Mode: "apply-before-merge"},
+			{Name: "service-tfbuddy", Organization: "zapier-test", Mode: "apply-before-merge"},
+		}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// First workspace is missing from TFC
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", "deleted-ws").
+		Return(nil, fmt.Errorf("resource not found"))
+	// Second workspace exists and has the locking tag
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", "service-tfbuddy").
+		Return(&tfe.Workspace{ID: "service-tfbuddy"}, nil)
+	testSuite.MockApiClient.EXPECT().GetTagsByQuery(gomock.Any(), "service-tfbuddy", "tfbuddylock-101").
+		Return([]string{"tfbuddylock-101"}, nil)
+	testSuite.MockApiClient.EXPECT().RemoveTagsByQuery(gomock.Any(), "service-tfbuddy", "tfbuddylock-101").
+		Return(nil)
+
+	// handleError posts an MR comment when the first workspace fails
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestComment(
+		gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS,
+		"Error: error getting workspace: resource not found",
+	).Return(nil)
+
+	// Summary discussion is posted with the successfully cleaned workspace
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(
+		gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS,
+		"Released locks for workspaces: service-tfbuddy",
+	).Return(testSuite.MockGitDisc, nil)
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.PlanAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	if err := trigger.TriggerCleanupEvent(ctx); err != nil {
+		t.Fatalf("cleanup should not fail when a workspace is missing, got: %v", err)
+	}
+}
+
+// TestTFCEvents_UnlockAlreadyUnlocked_StillRemovesTags verifies that running
+// `tfc unlock` against a workspace that is already unlocked still removes
+// stale tfbuddylock-* tags (treating ErrWorkspaceUnlocked as non-fatal).
+func TestTFCEvents_UnlockAlreadyUnlocked_StillRemovesTags(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// Workspace is already unlocked → LockUnlockWorkspace returns ErrWorkspaceUnlocked
+	// via the TFCTrigger.LockUnlockWorkspace wrapper (no API call is made by the wrapper
+	// in this branch, so we don't set an expectation on MockApiClient.LockUnlockWorkspace).
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", "service-tfbuddy").Return(&tfe.Workspace{ID: "service-tfbuddy", Locked: false}, nil)
+
+	// Stale tfbuddylock tags should still be removed
+	testSuite.MockApiClient.EXPECT().RemoveTagsByQuery(gomock.Any(), gomock.Any(), "tfbuddylock").Return(nil)
+
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(
+		gomock.Any(),
+		testSuite.MetaData.MRIID,
+		testSuite.MetaData.ProjectNameNS,
+		"Successfully unlocked Workspace `zapier-test/service-tfbuddy`",
+	).Return(testSuite.MockGitDisc, nil)
+
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.UnlockAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+		Workspace:                "service-tfbuddy",
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(triggeredWS.Errored) != 0 {
+		t.Fatalf("expected no errored workspaces, got: %v", triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) != 1 {
+		t.Fatal("expected unlock to still proceed and remove tags")
+	}
+}

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -960,6 +960,7 @@ func TestTFCEvents_StaleLock_OpenMR_Rejects(t *testing.T) {
 	// Locking MR 99 is still open — no auto-clean should happen
 	mockLockingMR := mocks.NewMockDetailedMR(mockCtrl)
 	mockLockingMR.EXPECT().GetState().Return("opened")
+	mockLockingMR.EXPECT().GetWebURL().Return("https://gitlab.com/zapier/tfbuddy/-/merge_requests/99")
 	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), 99, testSuite.MetaData.ProjectNameNS).Return(mockLockingMR, nil)
 
 	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
@@ -984,8 +985,8 @@ func TestTFCEvents_StaleLock_OpenMR_Rejects(t *testing.T) {
 	if len(triggeredWS.Errored) != 1 {
 		t.Fatalf("expected 1 errored workspace, got: %d", len(triggeredWS.Errored))
 	}
-	if !strings.Contains(triggeredWS.Errored[0].Error, "workspace is locked by another MR! 99") {
-		t.Fatalf("expected locked-by-MR error, got: %s", triggeredWS.Errored[0].Error)
+	if !strings.Contains(triggeredWS.Errored[0].Error, "workspace is locked by another MR! https://gitlab.com/zapier/tfbuddy/-/merge_requests/99") {
+		t.Fatalf("expected locked-by-MR error with URL, got: %s", triggeredWS.Errored[0].Error)
 	}
 }
 
@@ -1008,6 +1009,7 @@ func TestTFCEvents_StaleLock_RemovalFailure_Errors(t *testing.T) {
 
 	mockLockingMR := mocks.NewMockDetailedMR(mockCtrl)
 	mockLockingMR.EXPECT().GetState().Return("merged")
+	mockLockingMR.EXPECT().GetWebURL().Return("https://gitlab.com/zapier/tfbuddy/-/merge_requests/99")
 	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), 99, testSuite.MetaData.ProjectNameNS).Return(mockLockingMR, nil)
 
 	// Tag removal fails → apply should abort with error
@@ -1035,8 +1037,8 @@ func TestTFCEvents_StaleLock_RemovalFailure_Errors(t *testing.T) {
 	if len(triggeredWS.Errored) != 1 {
 		t.Fatalf("expected 1 errored workspace, got: %d", len(triggeredWS.Errored))
 	}
-	if !strings.Contains(triggeredWS.Errored[0].Error, "failed to auto-clean stale lock tag from MR 99") {
-		t.Fatalf("expected stale-lock cleanup error, got: %s", triggeredWS.Errored[0].Error)
+	if !strings.Contains(triggeredWS.Errored[0].Error, "failed to auto-clean stale lock tag from MR https://gitlab.com/zapier/tfbuddy/-/merge_requests/99") {
+		t.Fatalf("expected stale-lock cleanup error with URL, got: %s", triggeredWS.Errored[0].Error)
 	}
 }
 

--- a/pkg/vcs/github/vcs_types.go
+++ b/pkg/vcs/github/vcs_types.go
@@ -54,6 +54,9 @@ func (gm *GithubPR) GetTitle() string {
 func (gm *GithubPR) GetTargetBranch() string {
 	return gm.PullRequest.GetBase().GetRef()
 }
+func (gm *GithubPR) GetState() string {
+	return gm.PullRequest.GetState()
+}
 func (gm *GithubPR) IsApproved() bool {
 	return *gm.MergeableState != "blocked"
 }

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -437,6 +437,9 @@ func (gm *GitlabMR) GetTitle() string {
 func (gm *GitlabMR) GetTargetBranch() string {
 	return gm.MergeRequest.TargetBranch
 }
+func (gm *GitlabMR) GetState() string {
+	return gm.MergeRequest.State
+}
 
 type GitlabMRAuthor struct {
 	*gogitlab.BasicUser

--- a/pkg/vcs/interfaces.go
+++ b/pkg/vcs/interfaces.go
@@ -45,6 +45,7 @@ type DetailedMR interface {
 	MR
 	GetWebURL() string
 	GetTitle() string
+	GetState() string
 }
 type MR interface {
 	MRBranches


### PR DESCRIPTION
The TriggerCleanupEvent loop would crash (nil pointer dereference) when any workspace in .tfbuddy.yaml no longer exists in TFC, preventing lock cleanup for all remaining workspaces. This caused stale tfbuddylock-* tags to accumulate, blocking new applies even after the locking MR was merged.

- Add continue after workspace/tag lookup errors in cleanup loop so one missing workspace doesn't break cleanup for the rest
- Add stale lock auto-recovery: when a workspace is locked by another MR, check if that MR is merged/closed and auto-clean the tag
- Update tfc unlock to also remove tfbuddylock-* tags, giving users a way to manually clear stale tag locks
- Add GetState() to DetailedMR interface for MR state inspection