### PR TITLE
CLOUD-695 Parallelize workspace triggers and rate-limit TFC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ and then passes status updates of those Runs back to the Merge/Pull Request in t
 
 For MRs with multiple workspaces, TFBuddy tracks each workspace independently and can automatically clean up old plan/apply comments, keeping only the most recent one per workspace and action type. Set `TFBUDDY_DELETE_OLD_COMMENTS` to enable this.
 
+When an MR touches multiple workspaces, TFBuddy triggers the runs in parallel (default 4 concurrent, tunable via `TFBUDDY_WORKSPACE_CONCURRENCY`) and rate-limits its TFC API client (default 30 req/s, tunable via `TFBUDDY_TFC_RATE_LIMIT_RPS` / `_BURST`) so concurrent triggers cooperate with TFC's per-token limit.
+
 
 ### Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,10 @@ Once the apply completes TF Buddy will update the PR indicating what was changed
 
 When `TFBUDDY_DELETE_OLD_COMMENTS` is set, TFBuddy automatically cleans up old discussion threads to keep MRs/PRs readable. Each comment is tagged with an invisible HTML marker identifying its workspace and action (plan or apply). When a new run completes, TFBuddy deletes older discussions that match the same workspace and action, keeping only the latest one. This is workspace-scoped: if your MR triggers runs in multiple workspaces, each workspace retains its own most recent plan and apply comment independently. Previous run URLs are collected into a collapsible "Previous TFC Urls" table on the latest comment.
 
+#### Parallel Workspace Triggering
+
+When an MR/PR touches multiple workspaces, TFBuddy triggers their TFC runs in parallel using a bounded `errgroup` (default `TFBUDDY_WORKSPACE_CONCURRENCY=4`). Each workspace owns its own discussion thread and run. To cooperate with TFC's per-token API limit, the TFC HTTP client is wrapped with a token-bucket rate limiter (default `TFBUDDY_TFC_RATE_LIMIT_RPS=30`, burst `TFBUDDY_TFC_RATE_LIMIT_BURST=30`).
+
 Example of how an error is reported
 
 ![error](img/error.png)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,12 @@ env:
   # workspace, keeping only the most recent one. Discussions for other workspaces or
   # actions are preserved. Set to "false" or remove to disable.
   TFBUDDY_DELETE_OLD_COMMENTS: "true"
+  # Optional: max workspaces triggered concurrently when an MR touches multiple workspaces (default: 4).
+  TFBUDDY_WORKSPACE_CONCURRENCY: "4"
+  # Optional: client-side TFC API rate limit, requests per second / burst (defaults: 30 / 30).
+  # Defaults match TFC's documented per-token limit; protects against 429s when many workspaces fan out.
+  TFBUDDY_TFC_RATE_LIMIT_RPS: "30"
+  TFBUDDY_TFC_RATE_LIMIT_BURST: "30"
 ```
 
 For sensitive environment variables use `secrets.envs` which can contain a list of key/value pairs

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.14.0
+	golang.org/x/time v0.11.0
 	google.golang.org/grpc v1.72.1
 	gopkg.in/dealancer/validate.v2 v2.1.0
 	gopkg.in/errgo.v2 v2.1.0
@@ -113,10 +115,8 @@ require (
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250519155744-55703ea1f237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/pkg/tfc_api/api_client.go
+++ b/pkg/tfc_api/api_client.go
@@ -3,14 +3,52 @@ package tfc_api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
 )
+
+const (
+	tfcRateLimitRPSEnv     = "TFBUDDY_TFC_RATE_LIMIT_RPS"
+	tfcRateLimitBurstEnv   = "TFBUDDY_TFC_RATE_LIMIT_BURST"
+	defaultTFCRateLimitRPS = 30
+	defaultTFCRateBurst    = 30
+)
+
+// rateLimitedTransport blocks each request on a shared token bucket so
+// concurrent triggers cooperatively stay under TFC's per-token API limit.
+type rateLimitedTransport struct {
+	rt      http.RoundTripper
+	limiter *rate.Limiter
+}
+
+func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.limiter.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return t.rt.RoundTrip(req)
+}
+
+func envIntOrDefault(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		log.Warn().Str("env", key).Str("value", raw).Int("default", fallback).
+			Msg("invalid value, falling back to default")
+		return fallback
+	}
+	return n
+}
 
 //go:generate mockgen -source api_client.go -destination=../mocks/mock_tfc_api.go -package=mocks github.com/zapier/tfbuddy/pkg/tfc_api
 type ApiClient interface {
@@ -35,8 +73,16 @@ func NewTFCClient() ApiClient {
 		log.Fatal().Msg("TFC_TOKEN not set")
 	}
 
+	rps := envIntOrDefault(tfcRateLimitRPSEnv, defaultTFCRateLimitRPS)
+	burst := envIntOrDefault(tfcRateLimitBurstEnv, defaultTFCRateBurst)
+	limiter := rate.NewLimiter(rate.Limit(rps), burst)
+	log.Info().Int("rps", rps).Int("burst", burst).Msg("TFC client rate limit configured")
+
 	config := &tfe.Config{
 		Token: token,
+		HTTPClient: &http.Client{
+			Transport: &rateLimitedTransport{rt: http.DefaultTransport, limiter: limiter},
+		},
 	}
 
 	var err error

--- a/pkg/tfc_api/api_client_test.go
+++ b/pkg/tfc_api/api_client_test.go
@@ -1,0 +1,106 @@
+package tfc_api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// TestRateLimitedTransport_BlocksAtLimit fires concurrent requests through the
+// limiter; without it the multi-workspace fan-out would 429 on TFC.
+func TestRateLimitedTransport_BlocksAtLimit(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: &rateLimitedTransport{
+			rt:      http.DefaultTransport,
+			limiter: rate.NewLimiter(rate.Limit(5), 1),
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	const total = 6
+	var wg sync.WaitGroup
+	wg.Add(total)
+	start := time.Now()
+	for i := 0; i < total; i++ {
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&hits); got != total {
+		t.Fatalf("expected %d hits, got %d", total, got)
+	}
+	// At 5 req/s with burst=1, 6 concurrent requests must take ~1s; an
+	// unlimited client would finish almost instantly.
+	if elapsed < 700*time.Millisecond {
+		t.Fatalf("expected concurrent rate-limited calls to take >=700ms, got %s", elapsed)
+	}
+}
+
+// TestRateLimitedTransport_HonorsContextCancel ensures a caller can abandon a
+// request blocked on the limiter, so a cancelled batch unblocks promptly.
+func TestRateLimitedTransport_HonorsContextCancel(t *testing.T) {
+	limiter := rate.NewLimiter(rate.Limit(0.1), 1)
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("priming the bucket failed: %v", err)
+	}
+	transport := &rateLimitedTransport{rt: http.DefaultTransport, limiter: limiter}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.invalid", nil)
+
+	start := time.Now()
+	if _, err := transport.RoundTrip(req); err == nil {
+		t.Fatal("expected context-cancelled error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("RoundTrip should have returned promptly after context cancel, took %s", elapsed)
+	}
+}
+
+func TestEnvIntOrDefault(t *testing.T) {
+	const key = "TFBUDDY_TEST_RATE_LIMIT"
+	cases := []struct {
+		name     string
+		envVal   string
+		fallback int
+		want     int
+	}{
+		{"unset returns fallback", "", 30, 30},
+		{"valid value parsed", "42", 30, 42},
+		{"zero falls back", "0", 30, 30},
+		{"negative falls back", "-7", 30, 30},
+		{"garbage falls back", "not-a-number", 30, 30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(key, tc.envVal)
+			if got := envIntOrDefault(key, tc.fallback); got != tc.want {
+				t.Fatalf("envIntOrDefault(%q)=%d, want %d", tc.envVal, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -10,10 +10,12 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
@@ -23,6 +25,26 @@ import (
 	"github.com/zapier/tfbuddy/pkg/utils"
 	"github.com/zapier/tfbuddy/pkg/vcs"
 )
+
+const (
+	workspaceConcurrencyEnv     = "TFBUDDY_WORKSPACE_CONCURRENCY"
+	defaultWorkspaceConcurrency = 4
+)
+
+func getWorkspaceConcurrency() int {
+	raw := os.Getenv(workspaceConcurrencyEnv)
+	if raw == "" {
+		return defaultWorkspaceConcurrency
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		log.Warn().Str("env", workspaceConcurrencyEnv).Str("value", raw).
+			Int("default", defaultWorkspaceConcurrency).
+			Msg("invalid value, falling back to default")
+		return defaultWorkspaceConcurrency
+	}
+	return n
+}
 
 const (
 	ApplyAction TriggerAction = iota
@@ -404,34 +426,52 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 				log.Error().Err(err).Msg("could not update MR with message")
 			}
 		}
+
+		// Trigger workspaces in parallel so a batch of multiple workspaces
+		// completes quickly enough to avoid the GitLab webhook timeout that
+		// caused the upstream redelivery / duplicate-run bug. Each goroutine
+		// owns its own discussion thread and run. Goroutines never return an
+		// error: a single failed workspace must not cancel the rest of the
+		// batch via the errgroup context.
+		var statusMu sync.Mutex
+		recordErrored := func(name, errMsg string) {
+			statusMu.Lock()
+			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{Name: name, Error: errMsg})
+			statusMu.Unlock()
+		}
+		recordExecuted := func(name string) {
+			statusMu.Lock()
+			workspaceStatus.Executed = append(workspaceStatus.Executed, name)
+			statusMu.Unlock()
+		}
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(getWorkspaceConcurrency())
+		cloneDir := repo.GetLocalDirectory()
+
 		for _, cfgWS := range triggeredWorkspaces {
-			// check allow / deny lists
+			cfgWS := cfgWS
 			if !isWorkspaceAllowed(cfgWS.Name, cfgWS.Organization) {
 				log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: "Ignoring workspace, because of allow/deny list.",
-				})
+				recordErrored(cfgWS.Name, "Ignoring workspace, because of allow/deny list.")
 				continue
 			}
 			if _, ok := modifiedWSMap[cfgWS.Name]; ok {
 				log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Strs("triggerDirs", cfgWS.TriggerDirs).Msg("Blocking workspace: relevant paths modified on target branch.")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs),
-				})
+				recordErrored(cfgWS.Name, fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs))
 				continue
 			}
-			if err := t.triggerRunForWorkspace(ctx, cfgWS, mr, repo.GetLocalDirectory()); err != nil {
-				log.Error().Err(err).Msg("could not trigger Run for Workspace")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: fmt.Sprintf("could not trigger Run for Workspace. %v", err),
-				})
-				continue
-			}
-			workspaceStatus.Executed = append(workspaceStatus.Executed, cfgWS.Name)
+			g.Go(func() error {
+				if err := t.triggerRunForWorkspace(gctx, cfgWS, mr, cloneDir); err != nil {
+					log.Error().Err(err).Str("ws", cfgWS.Name).Msg("could not trigger Run for Workspace")
+					recordErrored(cfgWS.Name, fmt.Sprintf("could not trigger Run for Workspace. %v", err))
+					return nil
+				}
+				recordExecuted(cfgWS.Name)
+				return nil
+			})
 		}
+		_ = g.Wait()
 
 	} else if t.GetTriggerSource() == CommentTrigger {
 		log.Error().Err(ErrNoChangesDetected)
@@ -629,9 +669,12 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	if err != nil {
 		return fmt.Errorf("could not create MR discussion thread for TFC run status updates. %w", err)
 	}
-	t.SetMergeRequestDiscussionID(disc.GetDiscussionID())
+	// Discussion + root note IDs are local to this invocation. They previously
+	// lived on t.cfg, which raced when multiple workspaces fan out in parallel.
+	discussionID := disc.GetDiscussionID()
+	var rootNoteID int64
 	if len(disc.GetMRNotes()) > 0 {
-		t.SetMergeRequestRootNoteID(disc.GetMRNotes()[0].GetNoteID())
+		rootNoteID = disc.GetMRNotes()[0].GetNoteID()
 	} else {
 		log.Debug().Msg("No MR Notes found")
 	}
@@ -659,10 +702,10 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 		Bool("speculative", run.ConfigurationVersion.Speculative).
 		Msg("created TFC run")
 
-	return t.publishRunToStream(ctx, run, cfgWS)
+	return t.publishRunToStream(ctx, run, cfgWS, discussionID, rootNoteID)
 }
 
-func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS *TFCWorkspace) error {
+func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS *TFCWorkspace, discussionID string, rootNoteID int64) error {
 	ctx, span := otel.Tracer("TFC").Start(ctx, "publishRunToStream")
 	defer span.End()
 
@@ -675,8 +718,8 @@ func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS
 		CommitSHA:                            t.GetCommitSHA(),
 		MergeRequestProjectNameWithNamespace: t.GetProjectNameWithNamespace(),
 		MergeRequestIID:                      t.GetMergeRequestIID(),
-		DiscussionID:                         t.GetMergeRequestDiscussionID(),
-		RootNoteID:                           t.GetMergeRequestRootNoteID(),
+		DiscussionID:                         discussionID,
+		RootNoteID:                           rootNoteID,
 		VcsProvider:                          t.GetVcsProvider(),
 		AutoMerge:                            cfgWS.AutoMerge,
 	}

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1213,5 +1214,152 @@ func TestTFCEvents_UnlockAlreadyUnlocked_StillRemovesTags(t *testing.T) {
 	}
 	if len(triggeredWS.Executed) != 1 {
 		t.Fatal("expected unlock to still proceed and remove tags")
+	}
+}
+
+// buildParallelWorkspacesConfig builds an N-workspace ProjectConfig where each
+// workspace points at a unique service directory.
+func buildParallelWorkspacesConfig(n int) *tfc_trigger.ProjectConfig {
+	wss := make([]*tfc_trigger.TFCWorkspace, 0, n)
+	for i := 0; i < n; i++ {
+		wss = append(wss, &tfc_trigger.TFCWorkspace{
+			Name:         fmt.Sprintf("service-tfbuddy-%02d", i),
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+			Dir:          fmt.Sprintf("services/svc%02d/", i),
+		})
+	}
+	return &tfc_trigger.ProjectConfig{Workspaces: wss}
+}
+
+// TestTFCEvents_WorkspacesParallel covers the core fix: an MR that touches
+// multiple workspaces fans out concurrently instead of running sequentially.
+// The wall-clock check below would fail if the loop regressed to sequential.
+func TestTFCEvents_WorkspacesParallel(t *testing.T) {
+	const numWorkspaces = 20
+	cfg := buildParallelWorkspacesConfig(numWorkspaces)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	modified := make([]string, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
+	}
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS, gomock.Any()).Return(testSuite.MockGitDisc, nil).Times(numWorkspaces)
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", gomock.Any()).DoAndReturn(func(_ context.Context, _, name string) (*tfe.Workspace, error) {
+		return &tfe.Workspace{ID: name}, nil
+	}).AnyTimes()
+
+	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts *tfc_api.ApiRunOptions) (*tfe.Run, error) {
+		// Hold the slot long enough that goroutines must overlap.
+		time.Sleep(20 * time.Millisecond)
+		return &tfe.Run{
+			ID: "run-" + opts.Workspace,
+			Workspace: &tfe.Workspace{Name: opts.Workspace,
+				Organization: &tfe.Organization{Name: "zapier-test"},
+			},
+			ConfigurationVersion: &tfe.ConfigurationVersion{Speculative: false}}, nil
+	}).Times(numWorkspaces)
+	testSuite.MockStreamClient.EXPECT().AddRunMeta(gomock.Any()).Times(numWorkspaces)
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+
+	start := time.Now()
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggeredWS.Errored) != 0 {
+		t.Fatalf("expected no errored workspaces, got: %v", triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) != numWorkspaces {
+		t.Fatalf("expected %d executed workspaces, got %d", numWorkspaces, len(triggeredWS.Executed))
+	}
+	// Sequential would be 20 * 20ms = 400ms; with concurrency=4, ~100ms.
+	// 250ms upper bound flags a regression to sequential while leaving CI headroom.
+	if elapsed >= 250*time.Millisecond {
+		t.Fatalf("parallel triggers took too long (%s); did the loop regress to sequential?", elapsed)
+	}
+}
+
+// TestTFCEvents_ParallelPartialFailure verifies one failed workspace does not
+// abort the rest of the batch (which used to happen if errgroup.WithContext
+// were allowed to cancel siblings on error).
+func TestTFCEvents_ParallelPartialFailure(t *testing.T) {
+	const numWorkspaces = 6
+	cfg := buildParallelWorkspacesConfig(numWorkspaces)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	modified := make([]string, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
+	}
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS, gomock.Any()).Return(testSuite.MockGitDisc, nil).AnyTimes()
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", gomock.Any()).DoAndReturn(func(_ context.Context, _, name string) (*tfe.Workspace, error) {
+		return &tfe.Workspace{ID: name}, nil
+	}).AnyTimes()
+
+	const failName = "service-tfbuddy-02"
+	var failures int32
+	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts *tfc_api.ApiRunOptions) (*tfe.Run, error) {
+		if opts.Workspace == failName {
+			atomic.AddInt32(&failures, 1)
+			return nil, fmt.Errorf("simulated TFC failure")
+		}
+		return &tfe.Run{
+			ID: "run-" + opts.Workspace,
+			Workspace: &tfe.Workspace{Name: opts.Workspace,
+				Organization: &tfe.Organization{Name: "zapier-test"},
+			},
+			ConfigurationVersion: &tfe.ConfigurationVersion{Speculative: false}}, nil
+	}).Times(numWorkspaces)
+	testSuite.MockStreamClient.EXPECT().AddRunMeta(gomock.Any()).Times(numWorkspaces - 1)
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&failures); got != 1 {
+		t.Fatalf("expected exactly 1 simulated failure, got %d", got)
+	}
+	if len(triggeredWS.Errored) != 1 || triggeredWS.Errored[0].Name != failName {
+		t.Fatalf("expected only %s to be errored, got: %+v", failName, triggeredWS.Errored)
+	}
+	if len(triggeredWS.Executed) != numWorkspaces-1 {
+		t.Fatalf("expected %d executed workspaces, got %d (%v)", numWorkspaces-1, len(triggeredWS.Executed), triggeredWS.Executed)
 	}
 }


### PR DESCRIPTION
TFBuddy plan and apply events failed when multiple workspaces were triggered simultaneously (e.g. during batch updates, rebases). Each workspace was processed sequentially, so a batch easily exceeded GitLab's ~30s webhook timeout. GitLab then retransmitted the webhook, and the duplicated requests against an unrate-limited TFC client left runs half-created with incomplete MR comments.

This MR addresses the issue by:

* **Parallelizing `TriggerTFCEvents`** with a bounded `golang.org/x/sync/errgroup` (default 4 concurrent, tunable via `TFBUDDY_WORKSPACE_CONCURRENCY`). Per-workspace results aggregate under a mutex; goroutines never return errors so one failed workspace can't abort the rest of the batch.
* **Making discussion / root-note IDs goroutine-local** inside `triggerRunForWorkspace` (passed into `publishRunToStream` as arguments instead of stashed on `t.cfg`). Precondition for safe parallelism — without this, concurrent goroutines race on the shared struct field and workspaces can end up posting status updates to the wrong discussion thread. Behavior is otherwise unchanged: each workspace still creates exactly one new discussion with the same content as before.
* **Rate-limiting the TFC API HTTP client** with a token-bucket limiter (`golang.org/x/time/rate`, default 30 RPS / burst 30, tunable via `TFBUDDY_TFC_RATE_LIMIT_RPS` / `_BURST`). Concurrent triggers cooperatively stay under TFC's documented per-token limit, eliminating the 429 storms seen during multi-workspace batches.


### Testing

- Ran `go test -race ./pkg/tfc_trigger/... ./pkg/tfc_api/...` — passes clean.

- New tests cover: parallel fan-out timing (TestTFCEvents_WorkspacesParallel), partial-failure isolation (TestTFCEvents_ParallelPartialFailure), concurrency-limit enforcement (TestTFCEvents_RespectsConcurrencyLimit), rate-limit blocking and context cancellation (TestRateLimitedTransport_*), and a regression guard against re-introducing http.Client.Timeout (TestNewRateLimitedHTTPClient_NoHardTimeout).

- End-to-end validated in Tilt against 20 real workspaces: 14 seconds from webhook arrival to all 20 TFC runs dispatched.
