### PR TITLE
feat: add TFE retry on 5xx errors and poll error tolerance

### DIFF
--- a/docs/superpowers/specs/2026-05-05-tfe-retry-backoff-design.md
+++ b/docs/superpowers/specs/2026-05-05-tfe-retry-backoff-design.md
@@ -1,0 +1,93 @@
+# TFE API Retry & Poll Error Tolerance
+
+**Date:** 2026-05-05  
+**Status:** Approved
+
+## Problem
+
+TFE API calls in tfbuddy have no retry or backoff logic. A single transient failure (rate limit, 5xx, network blip) propagates as a hard error, aborting the entire plan/apply workflow. The VCS clients (GitHub, GitLab) already use `cenkalti/backoff/v4` for retries; the TFE client has none.
+
+Additionally, the two polling loops that wait for long-running TFE operations crash or abort on transient read errors mid-poll.
+
+## Scope
+
+- Enable `RetryServerErrors` on the TFE client config
+- Make `pollCVWhilePending` tolerate transient read errors
+- Make `waitForRunCompletionOrFailure` tolerate transient read errors and guard against nil-run panic
+
+Out of scope: exponential backoff on polling intervals, `cenkalti/backoff` wrappers on individual TFE calls.
+
+## Design
+
+### 1. TFE Client Config (`pkg/tfc_api/api_client.go`)
+
+Change `NewTFCClient` to set `RetryServerErrors: true` on `tfe.Config`:
+
+```go
+config := &tfe.Config{
+    Token:             token,
+    RetryServerErrors: true,
+    RetryLogHook: func(lvl retryablehttp.LogLevel, msg string, args ...interface{}) {
+        log.Debug().Msgf("TFE retry: %s %v", msg, args)
+    },
+}
+```
+
+The `go-tfe` client wraps `go-retryablehttp` internally. With `RetryServerErrors: true`:
+- **429 rate limits**: backed off using the `Retry-After` header (already active by default)
+- **5xx server errors**: linear jitter backoff, 100ms–400ms wait, up to 30 retries
+
+The `RetryLogHook` makes retries visible in zerolog output, consistent with the rest of the codebase.
+
+### 2. CV Polling Error Tolerance (`pkg/tfc_api/api_driven_runs.go`)
+
+`pollCVWhilePending` currently returns immediately on any read error. After `go-tfe` exhausts its own retries, a still-failing call should not abort the upload — it should log and continue to the next poll iteration, respecting the existing 30-iteration / 30-second total timeout.
+
+```go
+func (c *TFCClient) pollCVWhilePending(ctx context.Context, cv *tfe.ConfigurationVersion) (*tfe.ConfigurationVersion, error) {
+    for i := 0; i < 30; i++ {
+        cv, err := c.Client.ConfigurationVersions.Read(ctx, cv.ID)
+        if err != nil {
+            log.Warn().Err(err).Msg("transient error reading CV status, retrying")
+            time.Sleep(1 * time.Second)
+            continue
+        }
+        if cv.Status != tfe.ConfigurationPending {
+            return cv, nil
+        }
+        time.Sleep(1 * time.Second)
+    }
+    return nil, fmt.Errorf("timed out waiting for CV to move from pending")
+}
+```
+
+### 3. Run Status Polling Error Tolerance (`pkg/tfc_utils/ci_job_run_status.go`)
+
+`waitForRunCompletionOrFailure` currently logs the error but proceeds to call `printRunInfo(run, ...)` with a potentially nil `run`, which will panic. Fix: skip the iteration on error.
+
+```go
+run, err := tfcClient.GetRun(ctx, runID)
+if err != nil {
+    log.Printf("transient error reading run %s, retrying: %v\n", runID, err)
+    continue
+}
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/tfc_api/api_client.go` | Set `RetryServerErrors: true` + `RetryLogHook` on `tfe.Config` |
+| `pkg/tfc_api/api_driven_runs.go` | `pollCVWhilePending`: continue on error instead of returning |
+| `pkg/tfc_utils/ci_job_run_status.go` | `waitForRunCompletionOrFailure`: continue on error, guard nil run |
+
+## Testing
+
+- `RetryServerErrors` behavior is tested by `go-tfe` itself — no new unit tests needed for that.
+- The polling loop changes eliminate a nil-run panic path — existing mock-based tests in `ci_job_runner_test.go` should continue to pass.
+- Verify manually: run existing test suite (`go test ./...`).
+
+## Risks
+
+- **Double-retry on polling read errors**: `GetRun` inside the polling loop will itself retry up to 30 times via `go-retryablehttp` before returning an error. The loop then waits 10s and retries again. This is intentional — the outer loop is about polling state changes, not HTTP reliability.
+- **RetryMax = 30 at 100–400ms**: worst case ~12s of retries per call. Acceptable for plan/apply operations which are already long-running.

--- a/docs/superpowers/specs/2026-05-05-tfe-retry-backoff-design.md
+++ b/docs/superpowers/specs/2026-05-05-tfe-retry-backoff-design.md
@@ -27,15 +27,15 @@ Change `NewTFCClient` to set `RetryServerErrors: true` on `tfe.Config`:
 config := &tfe.Config{
     Token:             token,
     RetryServerErrors: true,
-    RetryLogHook: func(lvl retryablehttp.LogLevel, msg string, args ...interface{}) {
-        log.Debug().Msgf("TFE retry: %s %v", msg, args)
+    RetryLogHook: func(attemptNum int, _ *http.Response) {
+        log.Debug().Int("attempt", attemptNum).Msg("TFE request retry")
     },
 }
 ```
 
-The `go-tfe` client wraps `go-retryablehttp` internally. With `RetryServerErrors: true`:
+`tfe.RetryLogHook` is defined as `func(attemptNum int, resp *http.Response)`. No `retryablehttp` import is needed, but `"net/http"` must be added to the import block in `api_client.go` (it is not currently imported there). The `go-tfe` client wraps `go-retryablehttp` internally. With `RetryServerErrors: true`:
 - **429 rate limits**: backed off using the `Retry-After` header (already active by default)
-- **5xx server errors**: linear jitter backoff, 100ms–400ms wait, up to 30 retries
+- **5xx server errors**: go-tfe's custom `retryHTTPBackoff` overrides the base wait range to **700ms–900ms** per attempt (linear jitter), up to 30 retries
 
 The `RetryLogHook` makes retries visible in zerolog output, consistent with the rest of the codebase.
 
@@ -46,14 +46,16 @@ The `RetryLogHook` makes retries visible in zerolog output, consistent with the 
 ```go
 func (c *TFCClient) pollCVWhilePending(ctx context.Context, cv *tfe.ConfigurationVersion) (*tfe.ConfigurationVersion, error) {
     for i := 0; i < 30; i++ {
-        cv, err := c.Client.ConfigurationVersions.Read(ctx, cv.ID)
+        // Use a named variable to avoid shadowing the outer cv parameter.
+        // The CV ID is stable across iterations so the original cv.ID is always correct.
+        result, err := c.Client.ConfigurationVersions.Read(ctx, cv.ID)
         if err != nil {
             log.Warn().Err(err).Msg("transient error reading CV status, retrying")
             time.Sleep(1 * time.Second)
             continue
         }
-        if cv.Status != tfe.ConfigurationPending {
-            return cv, nil
+        if result.Status != tfe.ConfigurationPending {
+            return result, nil
         }
         time.Sleep(1 * time.Second)
     }
@@ -61,9 +63,11 @@ func (c *TFCClient) pollCVWhilePending(ctx context.Context, cv *tfe.Configuratio
 }
 ```
 
+Note: the existing code uses `:=` for the inner `cv`, shadowing the parameter. The implementation here uses a distinct `result` variable to make the intent explicit. The CV ID is immutable so both approaches read the same ID on every iteration.
+
 ### 3. Run Status Polling Error Tolerance (`pkg/tfc_utils/ci_job_run_status.go`)
 
-`waitForRunCompletionOrFailure` currently logs the error but proceeds to call `printRunInfo(run, ...)` with a potentially nil `run`, which will panic. Fix: skip the iteration on error.
+`waitForRunCompletionOrFailure` currently logs the error but proceeds to call `printRunInfo(run, ...)` with a potentially nil `run`. `isRunning(run)` already nil-guards (returns false for nil), but `printRunInfo` does not — it dereferences `run.ID` unconditionally. Fix: `continue` on error before reaching either call.
 
 ```go
 run, err := tfcClient.GetRun(ctx, runID)
@@ -71,6 +75,7 @@ if err != nil {
     log.Printf("transient error reading run %s, retrying: %v\n", runID, err)
     continue
 }
+// printRunInfo and isRunning are only reached when run is non-nil
 ```
 
 ## Files Changed
@@ -90,4 +95,4 @@ if err != nil {
 ## Risks
 
 - **Double-retry on polling read errors**: `GetRun` inside the polling loop will itself retry up to 30 times via `go-retryablehttp` before returning an error. The loop then waits 10s and retries again. This is intentional — the outer loop is about polling state changes, not HTTP reliability.
-- **RetryMax = 30 at 100–400ms**: worst case ~12s of retries per call. Acceptable for plan/apply operations which are already long-running.
+- **RetryMax = 30 at 700–900ms**: worst case ~27s of retries per call for 5xx errors. Acceptable for plan/apply operations which are already long-running.

--- a/pkg/tfc_api/api_client.go
+++ b/pkg/tfc_api/api_client.go
@@ -3,6 +3,7 @@ package tfc_api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/hashicorp/go-tfe"
@@ -36,7 +37,11 @@ func NewTFCClient() ApiClient {
 	}
 
 	config := &tfe.Config{
-		Token: token,
+		Token:             token,
+		RetryServerErrors: true,
+		RetryLogHook: func(attemptNum int, _ *http.Response) {
+			log.Debug().Int("attempt", attemptNum).Msg("TFE request retry")
+		},
 	}
 
 	var err error

--- a/pkg/tfc_api/api_driven_runs.go
+++ b/pkg/tfc_api/api_driven_runs.go
@@ -120,12 +120,14 @@ func (c *TFCClient) createConfigurationVersion(opts *ApiRunOptions, ctx context.
 
 func (c *TFCClient) pollCVWhilePending(ctx context.Context, cv *tfe.ConfigurationVersion) (*tfe.ConfigurationVersion, error) {
 	for i := 0; i < 30; i++ {
-		cv, err := c.Client.ConfigurationVersions.Read(ctx, cv.ID)
+		result, err := c.Client.ConfigurationVersions.Read(ctx, cv.ID)
 		if err != nil {
-			return nil, err
+			log.Warn().Err(err).Msg("transient error reading CV status, retrying")
+			time.Sleep(1 * time.Second)
+			continue
 		}
-		if cv.Status != tfe.ConfigurationPending {
-			return cv, nil
+		if result.Status != tfe.ConfigurationPending {
+			return result, nil
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/pkg/tfc_api/api_driven_runs_test.go
+++ b/pkg/tfc_api/api_driven_runs_test.go
@@ -1,0 +1,78 @@
+package tfc_api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+)
+
+// fakeCV implements tfe.ConfigurationVersions with configurable per-call results.
+type fakeCV struct {
+	calls   int
+	results []cvResult
+}
+
+type cvResult struct {
+	cv  *tfe.ConfigurationVersion
+	err error
+}
+
+func (f *fakeCV) Read(ctx context.Context, cvID string) (*tfe.ConfigurationVersion, error) {
+	i := f.calls
+	f.calls++
+	if i < len(f.results) {
+		return f.results[i].cv, f.results[i].err
+	}
+	return nil, errors.New("fakeCV: unexpected extra call")
+}
+
+func (f *fakeCV) List(_ context.Context, _ string, _ *tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
+	panic("unexpected call")
+}
+func (f *fakeCV) Create(_ context.Context, _ string, _ tfe.ConfigurationVersionCreateOptions) (*tfe.ConfigurationVersion, error) {
+	panic("unexpected call")
+}
+func (f *fakeCV) CreateForRegistryModule(_ context.Context, _ tfe.RegistryModuleID) (*tfe.ConfigurationVersion, error) {
+	panic("unexpected call")
+}
+func (f *fakeCV) ReadWithOptions(_ context.Context, _ string, _ *tfe.ConfigurationVersionReadOptions) (*tfe.ConfigurationVersion, error) {
+	panic("unexpected call")
+}
+func (f *fakeCV) Upload(_ context.Context, _ string, _ string) error  { panic("unexpected call") }
+func (f *fakeCV) UploadTarGzip(_ context.Context, _ string, _ io.Reader) error {
+	panic("unexpected call")
+}
+func (f *fakeCV) Archive(_ context.Context, _ string) error                    { panic("unexpected call") }
+func (f *fakeCV) Download(_ context.Context, _ string) ([]byte, error)         { panic("unexpected call") }
+func (f *fakeCV) SoftDeleteBackingData(_ context.Context, _ string) error      { panic("unexpected call") }
+func (f *fakeCV) RestoreBackingData(_ context.Context, _ string) error         { panic("unexpected call") }
+func (f *fakeCV) PermanentlyDeleteBackingData(_ context.Context, _ string) error {
+	panic("unexpected call")
+}
+
+func TestPollCVWhilePending_continuesOnTransientError(t *testing.T) {
+	fake := &fakeCV{
+		results: []cvResult{
+			{nil, errors.New("transient network error")},
+			{&tfe.ConfigurationVersion{Status: tfe.ConfigurationUploaded}, nil},
+		},
+	}
+
+	client := &TFCClient{Client: &tfe.Client{ConfigurationVersions: fake}}
+	cv := &tfe.ConfigurationVersion{ID: "cv-abc123"}
+
+	result, err := client.pollCVWhilePending(context.Background(), cv)
+
+	if err != nil {
+		t.Fatalf("expected no error after transient failure, got: %v", err)
+	}
+	if result.Status != tfe.ConfigurationUploaded {
+		t.Fatalf("expected ConfigurationUploaded, got: %v", result.Status)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("expected 2 Read calls, got: %d", fake.calls)
+	}
+}

--- a/pkg/tfc_utils/ci_job_run_status.go
+++ b/pkg/tfc_utils/ci_job_run_status.go
@@ -22,6 +22,8 @@ const TFC_RUN_STATUS_PREFIX = `Terraform Cloud/`
 const TFC_POLICY_STATUS_PREFIX = `sentinel/`
 const TFC_NO_CHANGE = "Run not triggered: Terraform working directories did not change."
 
+var retryInterval = 10 * time.Second
+
 var (
 	glClient  *gitlab.GitlabClient
 	tfcClient tfc_api.ApiClient
@@ -134,7 +136,6 @@ func waitForRunCompletionOrFailure(ctx context.Context, wg *sync.WaitGroup, comm
 	defer wg.Done()
 
 	attempts := 360
-	retryInterval := 10 * time.Second
 
 	for i := 0; i < attempts; i++ {
 		time.Sleep(retryInterval)
@@ -142,7 +143,8 @@ func waitForRunCompletionOrFailure(ctx context.Context, wg *sync.WaitGroup, comm
 		log.Println("Reading Run details.", runID)
 		run, err := tfcClient.GetRun(ctx, runID)
 		if err != nil {
-			log.Printf("err: %v\n", err)
+			log.Printf("transient error reading run %s, retrying: %v\n", runID, err)
+			continue
 		}
 
 		printRunInfo(run, "Run Details", wsName)

--- a/pkg/tfc_utils/ci_job_run_status_test.go
+++ b/pkg/tfc_utils/ci_job_run_status_test.go
@@ -1,0 +1,36 @@
+package tfc_utils
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zapier/tfbuddy/pkg/mocks"
+)
+
+func TestWaitForRunCompletionOrFailure_continuesOnGetRunError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	origInterval := retryInterval
+	retryInterval = 1 * time.Millisecond
+	defer func() { retryInterval = origInterval }()
+
+	origClient := tfcClient
+	mockTFC := mocks.NewMockApiClient(ctrl)
+	tfcClient = mockTFC
+	defer func() { tfcClient = origClient }()
+
+	// All GetRun calls return an error — the loop must continue, not panic.
+	mockTFC.EXPECT().GetRun(gomock.Any(), "run-123").Return(nil, errors.New("transient")).AnyTimes()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	// Should complete without panicking.
+	waitForRunCompletionOrFailure(context.Background(), wg, &gogitlab.CommitStatus{}, "ws", "run-123")
+}


### PR DESCRIPTION
## Summary

- Enable `RetryServerErrors: true` on the TFE client config so transient 5xx failures are retried automatically via go-tfe's built-in `go-retryablehttp` machinery (700ms–900ms linear jitter backoff, up to 30 attempts). Rate limit (429) retries were already active by default.
- Add `RetryLogHook` to surface retry attempts in zerolog output.
- Fix `pollCVWhilePending` (`pkg/tfc_api/api_driven_runs.go`) to continue polling on transient read errors instead of aborting the entire upload flow. Also fixes a variable shadowing bug in the loop.
- Fix `waitForRunCompletionOrFailure` (`pkg/tfc_utils/ci_job_run_status.go`) to `continue` on `GetRun` errors instead of passing a nil run to `printRunInfo`, which would panic.

## Test plan

- [ ] `TestPollCVWhilePending_continuesOnTransientError` — verifies CV polling survives a transient read error and succeeds on the next attempt
- [ ] `TestWaitForRunCompletionOrFailure_continuesOnGetRunError` — verifies the run status polling loop does not panic when `GetRun` returns an error
- [ ] `go test ./...` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)