### PR TITLE
CLOUD-695: Fan-Out workspace triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ and then passes status updates of those Runs back to the Merge/Pull Request in t
 
 For MRs with multiple workspaces, TFBuddy tracks each workspace independently and can automatically clean up old plan/apply comments, keeping only the most recent one per workspace and action type. Set `TFBUDDY_DELETE_OLD_COMMENTS` to enable this.
 
+Each touched workspace is dispatched onto a dedicated NATS JetStream queue and processed independently, so a single MR with many workspaces can no longer hold the webhook subscriber past `AckWait` (which previously caused JetStream redeliveries and duplicate TFC runs). The TFC API client is rate-limited (`TFBUDDY_TFC_RATE_LIMIT_RPS` / `_BURST`) so concurrent workers stay under TFC's documented per-token limit.
+
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and then passes status updates of those Runs back to the Merge/Pull Request in t
 
 For MRs with multiple workspaces, TFBuddy tracks each workspace independently and can automatically clean up old plan/apply comments, keeping only the most recent one per workspace and action type. Set `TFBUDDY_DELETE_OLD_COMMENTS` to enable this.
 
-Each touched workspace is dispatched onto a dedicated NATS JetStream queue and processed independently, so a single MR with many workspaces can no longer hold the webhook subscriber past `AckWait` (which previously caused JetStream redeliveries and duplicate TFC runs). The TFC API client is rate-limited (`TFBUDDY_TFC_RATE_LIMIT_RPS` / `_BURST`) so concurrent workers stay under TFC's documented per-token limit.
+Each touched workspace is dispatched onto a dedicated NATS JetStream queue and processed independently, so a single MR with many workspaces can no longer hold the webhook subscriber past `AckWait` (which previously caused JetStream redeliveries and duplicate TFC runs). The fan-out is gated by `TFBUDDY_WORKSPACE_FANOUT_ENABLED` (default `true`) so it can be turned off at runtime if needed. The TFC API client is rate-limited (`TFBUDDY_TFC_RATE_LIMIT_RPS` / `_BURST`) so concurrent workers stay under TFC's documented per-token limit.
 
 
 ### Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,16 @@ Example of how an error is reported
 A more detailed error message is provided if the error occurred within TF Buddy. If the error occurred during terraform plan or terraform apply it will not contain a detailed message. Instead the run link will take you to the Terraform workspace where you can debug the error.
 
 
+### Workspace Fan-Out
+
+When an MR/PR touches several Terraform workspaces, TFBuddy splits the work onto a dedicated NATS JetStream queue and processes each workspace independently. The MR/PR webhook subscriber only validates the event and publishes one fan-out message per workspace, so it ACKs well within JetStream's `AckWait`. A separate workspace worker drains the queue, with each delivery getting its own `AckWait` window — a slow workspace can no longer hold the parent message past `AckWait` and trigger a redelivery (which previously caused duplicate runs).
+
+Per-workspace state (discussion ID, root note ID) is local to the worker invocation, so concurrent deliveries cannot leak IDs across workspaces.
+
+### TFC API Rate Limiter
+
+The TFC API client wraps its HTTP transport with a token-bucket rate limiter (`TFBUDDY_TFC_RATE_LIMIT_RPS`, default `30`; burst `TFBUDDY_TFC_RATE_LIMIT_BURST`, default `30`) so concurrent workspace workers cooperatively stay under TFC's documented per-token limit. The client deliberately has no top-level `Timeout`: `ConfigurationVersions.Upload` streams the cloned repo and a fixed cap would truncate slow uploads on large repos. Per-call deadlines flow through `context.Context`.
+
 ### Webhook Management
 
 At Zapier we automate the creation of all relevant webhooks by leveraging Terraform to create them. The example below is a resource we use to hook up a Gitlab project and a Terraform Cloud workspace to TF Buddy.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,9 +29,17 @@ A more detailed error message is provided if the error occurred within TF Buddy.
 
 ### Workspace Fan-Out
 
-When an MR/PR touches several Terraform workspaces, TFBuddy splits the work onto a dedicated NATS JetStream queue and processes each workspace independently. The MR/PR webhook subscriber only validates the event and publishes one fan-out message per workspace, so it ACKs well within JetStream's `AckWait`. A separate workspace worker drains the queue, with each delivery getting its own `AckWait` window — a slow workspace can no longer hold the parent message past `AckWait` and trigger a redelivery (which previously caused duplicate runs).
+When an MR/PR touches several Terraform workspaces, TFBuddy splits the work onto a dedicated NATS JetStream queue and processes each workspace independently. The MR/PR webhook subscriber clones the repo once, evaluates which workspaces are blocked by changes on the target branch, and publishes one fan-out message per remaining workspace. A separate workspace worker drains the queue, with each delivery getting its own `AckWait` window — a slow workspace can no longer hold the parent message past `AckWait` and trigger a redelivery (which previously caused duplicate runs).
 
 Per-workspace state (discussion ID, root note ID) is local to the worker invocation, so concurrent deliveries cannot leak IDs across workspaces.
+
+The fan-out is gated by `TFBUDDY_WORKSPACE_FANOUT_ENABLED` (default `true`). Setting it to `false` falls back to the legacy inline per-MR loop, useful if you need to roll back at runtime without redeploying.
+
+Each fan-out message carries the upstream webhook delivery ID (`X-GitHub-Delivery` for GitHub, `X-Gitlab-Event-UUID`/`Idempotency-Key` for GitLab). That ID combined with the workspace name is used as the JetStream dedup key, so a single webhook fanning out to N workspaces produces N distinct keys, while a legitimate retrigger (a new push or comment within the dedup window) carries a fresh delivery ID and is *not* swallowed by the dedup window.
+
+Target-branch evaluation runs once in the publisher, so the MR-level "could not evaluate target branch" warning is posted at most once per delivery. Each worker then re-clones the repo to upload the workspace directory to TFC, so an MR touching N workspaces still does N+1 clones in fan-out mode. On large monorepos this measurably increases git egress and per-message latency; mitigate via `TFBUDDY_GITHUB_CLONE_DEPTH` / `TFBUDDY_GITLAB_CLONE_DEPTH`, or disable fan-out (`TFBUDDY_WORKSPACE_FANOUT_ENABLED=false`) and accept the AckWait risk.
+
+The workspace stream exposes the same `consumers >= 1` liveness check as the other streams, wired into `/live` so a stuck or unsubscribed worker is caught by Kubernetes probes rather than silently piling up unprocessed messages.
 
 ### TFC API Rate Limiter
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -108,6 +108,12 @@ If you're using minikube with Tilt we recommend following this [guide](https://g
 
 We use Earthly to simplify our CI/CD process with TF Buddy. This also simplifies testing changes locally before pushing them up to ensure your PR will pass all required checks. The best command to run is `earthly +unit-test` this will pull all the required dependencies (including any new ones that you have added). It will then run [go vet](https://pkg.go.dev/cmd/vet), and if those pass it will run `go test` with race detection enabled. You can also always run these commands directly `go test -race ./...` will run all tests in the repo with race detection enabled. Please ensure that `earthly +unit-test` is passing before opening a PR.
 
+Always run with `-race` when changing the trigger or TFC API code — those paths are concurrent (workspace fan-out, shared rate limiter):
+
+```console
+go test -race ./pkg/tfc_trigger/... ./pkg/tfc_api/...
+```
+
 #### Unit Tests
 
 We use [gomock](https://github.com/golang/mock) to simplify down some of our unit tests specifically in `tfc_trigger_tests.go` where a lot of our functionality needs to be tested. To reduce the burden of testing a new feature you can leverage the `TestSuite` in `pkg/mocks/helpers.go`. When you call `CreateTestSuite` it will return a set of stubs that should let you test most operations. To override stubs that are created within the TestSuite define them after calling `CreateTestSuite` but before calling `InitTestSuite`. This works because gomock will respect the order that stubs/mocks are defined which lets you override an EXPECT defined in TestSuite. This can be seen in this example:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,6 +69,7 @@ The full list of supported environment variables and flags is described below:
 |`TFBUDDY_GITHUB_CLONE_DEPTH`|`--github-clone-depth`|Git clone depth to use for GitHub merge request checkouts. Zero means full history.|`0`|
 |`TFBUDDY_GITLAB_CLONE_DEPTH`|`--gitlab-clone-depth`|Git clone depth to use for GitLab merge request checkouts. Zero means full history.|`0`|
 |`TFBUDDY_WORKSPACE_FANOUT_ENABLED`|`--workspace-fanout-enabled`|Enable per-workspace JetStream fan-out (one NATS message per workspace) to keep AckWait windows scoped per workspace. When disabled, TFBuddy falls back to the inline per-MR loop.|`true`|
+|`TFBUDDY_WORKSPACE_JETSTREAM_REPLICAS`|`--workspace-jetstream-replicas`|JetStream replica count for the workspace-trigger stream. Use 1 for single-node NATS or local dev; set to your NATS cluster size (often 3) in production for durability.|`1`|
 |`TFBUDDY_TFC_RATE_LIMIT_RPS`|`--tfc-rate-limit-rps`|Client-side rate limit (requests per second) for the Terraform Cloud API. Tuned to match TFC's documented per-token limit and prevent 429s when many workspaces are triggered concurrently.|`30`|
 |`TFBUDDY_TFC_RATE_LIMIT_BURST`|`--tfc-rate-limit-burst`|Burst capacity for the TFC API token-bucket rate limiter.|`30`|
 <!-- END GENERATED CONFIGURATION -->

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,6 +68,9 @@ The full list of supported environment variables and flags is described below:
 |`TFBUDDY_GITHUB_REPO_ALLOW_LIST`|`--github-repo-allow-list`|Comma-separated GitHub repository allow list prefixes.||
 |`TFBUDDY_GITHUB_CLONE_DEPTH`|`--github-clone-depth`|Git clone depth to use for GitHub merge request checkouts. Zero means full history.|`0`|
 |`TFBUDDY_GITLAB_CLONE_DEPTH`|`--gitlab-clone-depth`|Git clone depth to use for GitLab merge request checkouts. Zero means full history.|`0`|
+|`TFBUDDY_WORKSPACE_FANOUT_ENABLED`|`--workspace-fanout-enabled`|Enable per-workspace JetStream fan-out (one NATS message per workspace) to keep AckWait windows scoped per workspace. When disabled, TFBuddy falls back to the inline per-MR loop.|`true`|
+|`TFBUDDY_TFC_RATE_LIMIT_RPS`|`--tfc-rate-limit-rps`|Client-side rate limit (requests per second) for the Terraform Cloud API. Tuned to match TFC's documented per-token limit and prevent 429s when many workspaces are triggered concurrently.|`30`|
+|`TFBUDDY_TFC_RATE_LIMIT_BURST`|`--tfc-rate-limit-burst`|Burst capacity for the TFC API token-bucket rate limiter.|`30`|
 <!-- END GENERATED CONFIGURATION -->
 
 For sensitive environment variables use `secrets.envs` which can contain a list of key/value pairs

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.16.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v69 v69.2.0
 	github.com/hashicorp/go-tfe v1.80.0
@@ -27,6 +28,7 @@ require (
 	github.com/rzajac/zltest v0.12.0
 	github.com/sl1pm4t/gongs v0.0.0-20230501190600-06976a7fac23
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/ziflex/lecho/v3 v3.8.0
@@ -64,7 +66,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
@@ -102,7 +103,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.8.0 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.79.3
 	gopkg.in/dealancer/validate.v2 v2.1.0
 	gopkg.in/errgo.v2 v2.1.0
@@ -118,7 +119,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,47 +11,55 @@ import (
 )
 
 const (
-	KeyLogLevel                 = "log-level"
-	KeyDevMode                  = "dev-mode"
-	KeyOTELEnabled              = "otel-enabled"
-	KeyOTELCollectorHost        = "otel-collector-host"
-	KeyOTELCollectorPort        = "otel-collector-port"
-	KeyGitlabHookSecretKey      = "gitlab-hook-secret-key"
-	KeyGithubHookSecretKey      = "github-hook-secret-key"
-	KeyDefaultTFCOrganization   = "default-tfc-organization"
-	KeyWorkspaceAllowList       = "workspace-allow-list"
-	KeyWorkspaceDenyList        = "workspace-deny-list"
-	KeyAllowAutoMerge           = "allow-auto-merge"
-	KeyFailCIOnSentinelSoftFail = "fail-ci-on-sentinel-soft-fail"
-	KeyDeleteOldComments        = "delete-old-comments"
-	KeyNATSServiceURL           = "nats-service-url"
-	KeyGitlabProjectAllowList   = "gitlab-project-allow-list"
-	KeyLegacyProjectAllowList   = "project-allow-list"
-	KeyGithubRepoAllowList      = "github-repo-allow-list"
-	KeyGithubCloneDepth         = "github-clone-depth"
-	KeyGitlabCloneDepth         = "gitlab-clone-depth"
+	KeyLogLevel                   = "log-level"
+	KeyDevMode                    = "dev-mode"
+	KeyOTELEnabled                = "otel-enabled"
+	KeyOTELCollectorHost          = "otel-collector-host"
+	KeyOTELCollectorPort          = "otel-collector-port"
+	KeyGitlabHookSecretKey        = "gitlab-hook-secret-key"
+	KeyGithubHookSecretKey        = "github-hook-secret-key"
+	KeyDefaultTFCOrganization     = "default-tfc-organization"
+	KeyWorkspaceAllowList         = "workspace-allow-list"
+	KeyWorkspaceDenyList          = "workspace-deny-list"
+	KeyAllowAutoMerge             = "allow-auto-merge"
+	KeyFailCIOnSentinelSoftFail   = "fail-ci-on-sentinel-soft-fail"
+	KeyDeleteOldComments          = "delete-old-comments"
+	KeyNATSServiceURL             = "nats-service-url"
+	KeyGitlabProjectAllowList     = "gitlab-project-allow-list"
+	KeyLegacyProjectAllowList     = "project-allow-list"
+	KeyGithubRepoAllowList        = "github-repo-allow-list"
+	KeyGithubCloneDepth           = "github-clone-depth"
+	KeyGitlabCloneDepth           = "gitlab-clone-depth"
+	KeyWorkspaceFanoutEnabled     = "workspace-fanout-enabled"
+	KeyWorkspaceJetStreamReplicas = "workspace-jetstream-replicas"
+	KeyTFCRateLimitRPS            = "tfc-rate-limit-rps"
+	KeyTFCRateLimitBurst          = "tfc-rate-limit-burst"
 )
 
 type Config struct {
-	LogLevel                 string   `mapstructure:"log-level"`
-	DevMode                  bool     `mapstructure:"dev-mode"`
-	OTELEnabled              bool     `mapstructure:"otel-enabled"`
-	OTELCollectorHost        string   `mapstructure:"otel-collector-host"`
-	OTELCollectorPort        string   `mapstructure:"otel-collector-port"`
-	GitlabHookSecretKey      string   `mapstructure:"gitlab-hook-secret-key"`
-	GithubHookSecretKey      string   `mapstructure:"github-hook-secret-key"`
-	DefaultTFCOrganization   string   `mapstructure:"default-tfc-organization"`
-	WorkspaceAllowList       []string `mapstructure:"workspace-allow-list"`
-	WorkspaceDenyList        []string `mapstructure:"workspace-deny-list"`
-	AllowAutoMerge           bool     `mapstructure:"allow-auto-merge"`
-	FailCIOnSentinelSoftFail bool     `mapstructure:"fail-ci-on-sentinel-soft-fail"`
-	DeleteOldComments        bool     `mapstructure:"delete-old-comments"`
-	NATSServiceURL           string   `mapstructure:"nats-service-url"`
-	GitlabProjectAllowList   []string `mapstructure:"gitlab-project-allow-list"`
-	LegacyProjectAllowList   []string `mapstructure:"project-allow-list"`
-	GithubRepoAllowList      []string `mapstructure:"github-repo-allow-list"`
-	GithubCloneDepth         int      `mapstructure:"github-clone-depth"`
-	GitlabCloneDepth         int      `mapstructure:"gitlab-clone-depth"`
+	LogLevel                   string   `mapstructure:"log-level"`
+	DevMode                    bool     `mapstructure:"dev-mode"`
+	OTELEnabled                bool     `mapstructure:"otel-enabled"`
+	OTELCollectorHost          string   `mapstructure:"otel-collector-host"`
+	OTELCollectorPort          string   `mapstructure:"otel-collector-port"`
+	GitlabHookSecretKey        string   `mapstructure:"gitlab-hook-secret-key"`
+	GithubHookSecretKey        string   `mapstructure:"github-hook-secret-key"`
+	DefaultTFCOrganization     string   `mapstructure:"default-tfc-organization"`
+	WorkspaceAllowList         []string `mapstructure:"workspace-allow-list"`
+	WorkspaceDenyList          []string `mapstructure:"workspace-deny-list"`
+	AllowAutoMerge             bool     `mapstructure:"allow-auto-merge"`
+	FailCIOnSentinelSoftFail   bool     `mapstructure:"fail-ci-on-sentinel-soft-fail"`
+	DeleteOldComments          bool     `mapstructure:"delete-old-comments"`
+	NATSServiceURL             string   `mapstructure:"nats-service-url"`
+	GitlabProjectAllowList     []string `mapstructure:"gitlab-project-allow-list"`
+	LegacyProjectAllowList     []string `mapstructure:"project-allow-list"`
+	GithubRepoAllowList        []string `mapstructure:"github-repo-allow-list"`
+	GithubCloneDepth           int      `mapstructure:"github-clone-depth"`
+	GitlabCloneDepth           int      `mapstructure:"gitlab-clone-depth"`
+	WorkspaceFanoutEnabled     bool     `mapstructure:"workspace-fanout-enabled"`
+	WorkspaceJetStreamReplicas int      `mapstructure:"workspace-jetstream-replicas"`
+	TFCRateLimitRPS            int      `mapstructure:"tfc-rate-limit-rps"`
+	TFCRateLimitBurst          int      `mapstructure:"tfc-rate-limit-burst"`
 }
 
 var C Config
@@ -83,6 +91,10 @@ var bindings = []binding{
 	{key: KeyGithubRepoAllowList, defaultValue: []string{}, description: "Comma-separated GitHub repository allow list prefixes."},
 	{key: KeyGithubCloneDepth, defaultValue: 0, description: "Git clone depth to use for GitHub merge request checkouts. Zero means full history."},
 	{key: KeyGitlabCloneDepth, defaultValue: 0, description: "Git clone depth to use for GitLab merge request checkouts. Zero means full history."},
+	{key: KeyWorkspaceFanoutEnabled, defaultValue: true, description: "Enable per-workspace JetStream fan-out (one NATS message per workspace) to keep AckWait windows scoped per workspace. When disabled, TFBuddy falls back to the inline per-MR loop."},
+	{key: KeyWorkspaceJetStreamReplicas, defaultValue: 1, description: "JetStream replica count for the workspace-trigger stream. Use 1 for single-node NATS or local dev; set to your NATS cluster size (often 3) in production for durability."},
+	{key: KeyTFCRateLimitRPS, defaultValue: 30, description: "Client-side rate limit (requests per second) for the Terraform Cloud API. Tuned to match TFC's documented per-token limit and prevent 429s when many workspaces are triggered concurrently."},
+	{key: KeyTFCRateLimitBurst, defaultValue: 30, description: "Burst capacity for the TFC API token-bucket rate limiter."},
 }
 
 func init() {

--- a/pkg/gitlab_hooks/comment_actions.go
+++ b/pkg/gitlab_hooks/comment_actions.go
@@ -14,6 +14,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+// deliveryIDProvider is the optional accessor production envelopes implement
+// to thread the webhook delivery ID without widening vcs.MRCommentEvent.
+type deliveryIDProvider interface {
+	GetDeliveryID() string
+}
+
 // processNoteEvent processes GitLab Webhooks for Note events
 // In the Gitlab API, MR comments are called Notes
 func (w *GitlabEventWorker) processNoteEvent(ctx context.Context, event vcs.MRCommentEvent) (projectName string, err error) {
@@ -44,6 +50,9 @@ func (w *GitlabEventWorker) processNoteEvent(ctx context.Context, event vcs.MRCo
 	opts.TriggerOpts.MergeRequestIID = event.GetMR().GetInternalID()
 	opts.TriggerOpts.TriggerSource = tfc_trigger.CommentTrigger
 	opts.TriggerOpts.VcsProvider = "gitlab"
+	if dp, ok := event.(deliveryIDProvider); ok {
+		opts.TriggerOpts.DeliveryID = dp.GetDeliveryID()
+	}
 
 	cfg, err := tfc_trigger.NewTFCTriggerConfig(opts.TriggerOpts)
 	if err != nil {

--- a/pkg/gitlab_hooks/comment_actions.go
+++ b/pkg/gitlab_hooks/comment_actions.go
@@ -52,6 +52,9 @@ func (w *GitlabEventWorker) processNoteEvent(ctx context.Context, event vcs.MRCo
 	}
 
 	trigger := w.triggerCreation(w.cfg, w.gl, w.tfc, w.runstream, cfg)
+	if w.workspaceStream != nil {
+		trigger.SetWorkspaceStream(w.workspaceStream)
+	}
 
 	if event.GetAttributes().GetType() == string(gitlab.DiscussionNote) {
 		trigger.SetMergeRequestDiscussionID(event.GetAttributes().GetDiscussionID())

--- a/pkg/gitlab_hooks/handler.go
+++ b/pkg/gitlab_hooks/handler.go
@@ -28,6 +28,19 @@ import (
 const GitlabTokenHeader = "X-Gitlab-Token"
 const GitlabHookIgnoreReasonUnhandledEventType = "unhandled-event-type"
 
+// gitlabDeliveryHeaders identify a webhook delivery. Some integrations
+// surface only Idempotency-Key, so we accept either.
+var gitlabDeliveryHeaders = []string{"X-Gitlab-Event-UUID", "Idempotency-Key"}
+
+func gitlabDeliveryID(r *http.Request) string {
+	for _, h := range gitlabDeliveryHeaders {
+		if v := r.Header.Get(h); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 type TriggerCreationFunc func(appCfg config.Config,
 	gl vcs.GitClient,
 	tfc tfc_api.ApiClient,
@@ -118,6 +131,7 @@ func (h *GitlabHooksHandler) handler(c echo.Context) error {
 		msg := &MergeRequestEventMsg{
 			GitlabHookEvent: GitlabHookEvent{},
 			Payload:         event,
+			DeliveryID:      gitlabDeliveryID(c.Request()),
 		}
 
 		proj = event.Project.PathWithNamespace
@@ -132,6 +146,7 @@ func (h *GitlabHooksHandler) handler(c echo.Context) error {
 		if checkError(ctx, err, "could not decode Note/Comment event") {
 			break
 		}
+		event.DeliveryID = gitlabDeliveryID(c.Request())
 		log.Info().Str("project", event.Payload.GetProject().GetPathWithNamespace()).Int("mergeRequestID", event.Payload.GetMR().GetInternalID()).Str("discussionID", event.Payload.GetDiscussionID()).Msg("processing GitLab Note/Comment event")
 
 		proj = event.Payload.GetProject().GetPathWithNamespace()

--- a/pkg/gitlab_hooks/handler.go
+++ b/pkg/gitlab_hooks/handler.go
@@ -40,6 +40,7 @@ type GitlabHooksHandler struct {
 	gl              vcs.GitClient
 	runstream       runstream.StreamClient
 	triggerCreation TriggerCreationFunc
+	workspaceStream tfc_trigger.WorkspacePublisher
 
 	// hook streams and workers
 	hookSecretKey string
@@ -48,7 +49,7 @@ type GitlabHooksHandler struct {
 	hooksWorker   *GitlabEventWorker
 }
 
-func NewGitlabHooksHandler(cfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GitlabHooksHandler {
+func NewGitlabHooksHandler(cfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext, workspaceStream tfc_trigger.WorkspacePublisher) *GitlabHooksHandler {
 	notesStream := gongs.NewGenericStream[NoteEventMsg](js, noteEventsStreamSubject(), hooks_stream.HooksStreamName)
 	mrStream := gongs.NewGenericStream[MergeRequestEventMsg](js, mrEventsStreamSubject(), hooks_stream.HooksStreamName)
 
@@ -58,6 +59,7 @@ func NewGitlabHooksHandler(cfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiC
 		gl:              gl,
 		runstream:       rs,
 		triggerCreation: tfc_trigger.NewTFCTrigger,
+		workspaceStream: workspaceStream,
 		mrStream:        mrStream,
 		notesStream:     notesStream,
 		hookSecretKey:   cfg.GitlabHookSecretKey,

--- a/pkg/gitlab_hooks/hook_worker.go
+++ b/pkg/gitlab_hooks/hook_worker.go
@@ -18,6 +18,7 @@ type GitlabEventWorker struct {
 	gl              vcs.GitClient
 	runstream       runstream.StreamClient
 	triggerCreation TriggerCreationFunc
+	workspaceStream tfc_trigger.WorkspacePublisher
 }
 
 func NewGitlabEventWorker(h *GitlabHooksHandler, js nats.JetStreamContext) *GitlabEventWorker {
@@ -27,6 +28,7 @@ func NewGitlabEventWorker(h *GitlabHooksHandler, js nats.JetStreamContext) *Gitl
 		gl:              h.gl,
 		runstream:       h.runstream,
 		triggerCreation: tfc_trigger.NewTFCTrigger,
+		workspaceStream: h.workspaceStream,
 	}
 
 	_, err := h.mrStream.QueueSubscribe("gitlab_mr_event_worker", w.processMREventStreamMsg)

--- a/pkg/gitlab_hooks/mr_actions.go
+++ b/pkg/gitlab_hooks/mr_actions.go
@@ -37,6 +37,7 @@ func (w *GitlabEventWorker) processMergeRequestEvent(msg *MergeRequestEventMsg) 
 		MergeRequestIID:          event.ObjectAttributes.IID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 		VcsProvider:              "gitlab",
+		DeliveryID:               msg.DeliveryID,
 	})
 	if err != nil {
 		log.Error().Err(err).Msg("could not create TFCTriggerConfig")

--- a/pkg/gitlab_hooks/mr_actions.go
+++ b/pkg/gitlab_hooks/mr_actions.go
@@ -44,6 +44,9 @@ func (w *GitlabEventWorker) processMergeRequestEvent(msg *MergeRequestEventMsg) 
 	}
 
 	trigger := tfc_trigger.NewTFCTrigger(w.cfg, w.gl, w.tfc, w.runstream, cfg)
+	if w.workspaceStream != nil {
+		trigger.SetWorkspaceStream(w.workspaceStream)
+	}
 	switch event.ObjectAttributes.Action {
 	case "open", "reopen":
 		log.Debug().Str("project", projectName).Int("mergeRequestID", event.ObjectAttributes.IID).Msg("triggering TFC events for merge request")

--- a/pkg/gitlab_hooks/stream_msgs.go
+++ b/pkg/gitlab_hooks/stream_msgs.go
@@ -37,8 +37,11 @@ type NoteEventMsg struct {
 	GitlabHookEvent
 
 	Payload *gitlab.GitlabMergeCommentEvent `json:"payload"`
-	Carrier propagation.MapCarrier          `json:"Carrier"`
-	Context context.Context
+	// DeliveryID anchors the workspace fan-out dedup key to the upstream
+	// webhook (X-Gitlab-Event-UUID or Idempotency-Key).
+	DeliveryID string                 `json:"deliveryID"`
+	Carrier    propagation.MapCarrier `json:"Carrier"`
+	Context    context.Context
 }
 
 func (e *NoteEventMsg) GetId(ctx context.Context) string {
@@ -83,6 +86,10 @@ func (e *NoteEventMsg) GetLastCommit() vcs.Commit {
 	return e.Payload.GetLastCommit()
 }
 
+func (e *NoteEventMsg) GetDeliveryID() string {
+	return e.DeliveryID
+}
+
 // ----------------------------------------------
 
 func mrEventsStreamSubject() string {
@@ -92,9 +99,11 @@ func mrEventsStreamSubject() string {
 type MergeRequestEventMsg struct {
 	GitlabHookEvent
 
-	Payload *gogitlab.MergeEvent   `json:"payload"`
-	Carrier propagation.MapCarrier `json:"Carrier"`
-	Context context.Context
+	Payload *gogitlab.MergeEvent `json:"payload"`
+	// DeliveryID anchors the workspace fan-out dedup key to the upstream webhook.
+	DeliveryID string                 `json:"deliveryID"`
+	Carrier    propagation.MapCarrier `json:"Carrier"`
+	Context    context.Context
 }
 
 func (e *MergeRequestEventMsg) GetId(ctx context.Context) string {

--- a/pkg/hooks/server.go
+++ b/pkg/hooks/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/hooks_stream"
+	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
+	"github.com/zapier/tfbuddy/pkg/vcs"
 	"github.com/zapier/tfbuddy/pkg/vcs/github"
 	"github.com/ziflex/lecho/v3"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
@@ -52,7 +54,31 @@ func StartServer(cfg config.Config) {
 
 	// setup API clients
 	gl := gitlab.NewGitlabClient(cfg)
+	gh := github.NewGithubClient(cfg)
 	tfc := tfc_api.NewTFCClient()
+
+	// Per-workspace fan-out queue. The MR/PR webhook subscriber publishes one
+	// message per workspace it touches; the worker below drains them so each
+	// workspace has its own JetStream AckWait window. The flag lets operators
+	// fall back to the legacy inline path while we roll this out.
+	var workspaceStream tfc_trigger.WorkspacePublisher
+	if cfg.WorkspaceFanoutEnabled {
+		ws, err := tfc_trigger.NewWorkspaceStream(js)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not configure workspace trigger stream")
+		}
+		vcsClients := map[string]vcs.GitClient{
+			"gitlab": gl,
+			"github": gh,
+		}
+		if _, err := tfc_trigger.NewWorkspaceTriggerWorker(ws, vcsClients, tfc, rs); err != nil {
+			log.Fatal().Err(err).Msg("could not start workspace trigger worker")
+		}
+		health.AddLivenessCheck("workspace-trigger-stream", ws.HealthCheck)
+		workspaceStream = ws
+	} else {
+		log.Info().Msg("workspace fan-out disabled via config; using inline per-MR loop")
+	}
 
 	hooksGroup := e.Group("/hooks")
 
@@ -68,14 +94,13 @@ func StartServer(cfg config.Config) {
 	//
 	// Github
 	//
-	gh := github.NewGithubClient(cfg)
-	githubHooksHandler := ghHooks.NewGithubHooksHandler(cfg, gh, tfc, rs, js)
+	githubHooksHandler := ghHooks.NewGithubHooksHandler(cfg, gh, tfc, rs, js, workspaceStream)
 	hooksGroup.POST("/github/events", githubHooksHandler.Handler)
 
 	//
 	// Gitlab
 	//
-	gitlabGroupHandler := gitlab_hooks.NewGitlabHooksHandler(cfg, gl, tfc, rs, js)
+	gitlabGroupHandler := gitlab_hooks.NewGitlabHooksHandler(cfg, gl, tfc, rs, js, workspaceStream)
 	hooksGroup.POST("/gitlab/group", gitlabGroupHandler.GroupHandler())
 	hooksGroup.POST("/gitlab/project", gitlabGroupHandler.ProjectHandler())
 

--- a/pkg/hooks/server.go
+++ b/pkg/hooks/server.go
@@ -57,13 +57,11 @@ func StartServer(cfg config.Config) {
 	gh := github.NewGithubClient(cfg)
 	tfc := tfc_api.NewTFCClient()
 
-	// Per-workspace fan-out queue. The MR/PR webhook subscriber publishes one
-	// message per workspace it touches; the worker below drains them so each
-	// workspace has its own JetStream AckWait window. The flag lets operators
-	// fall back to the legacy inline path while we roll this out.
+	// Per-workspace fan-out queue. Flagged so operators can fall back to the
+	// legacy inline path during rollout.
 	var workspaceStream tfc_trigger.WorkspacePublisher
 	if cfg.WorkspaceFanoutEnabled {
-		ws, err := tfc_trigger.NewWorkspaceStream(js)
+		ws, err := tfc_trigger.NewWorkspaceStream(js, cfg.WorkspaceJetStreamReplicas)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not configure workspace trigger stream")
 		}
@@ -71,7 +69,7 @@ func StartServer(cfg config.Config) {
 			"gitlab": gl,
 			"github": gh,
 		}
-		if _, err := tfc_trigger.NewWorkspaceTriggerWorker(ws, vcsClients, tfc, rs); err != nil {
+		if _, err := tfc_trigger.NewWorkspaceTriggerWorker(ws, cfg, vcsClients, tfc, rs); err != nil {
 			log.Fatal().Err(err).Msg("could not start workspace trigger worker")
 		}
 		health.AddLivenessCheck("workspace-trigger-stream", ws.HealthCheck)

--- a/pkg/mocks/mock_tfc_trigger.go
+++ b/pkg/mocks/mock_tfc_trigger.go
@@ -20,6 +20,7 @@ import (
 type MockTrigger struct {
 	ctrl     *gomock.Controller
 	recorder *MockTriggerMockRecorder
+	isgomock struct{}
 }
 
 // MockTriggerMockRecorder is the mock recorder for MockTrigger.
@@ -201,6 +202,18 @@ func (m *MockTrigger) SetMergeRequestRootNoteID(id int64) {
 func (mr *MockTriggerMockRecorder) SetMergeRequestRootNoteID(id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMergeRequestRootNoteID", reflect.TypeOf((*MockTrigger)(nil).SetMergeRequestRootNoteID), id)
+}
+
+// SetWorkspaceStream mocks base method.
+func (m *MockTrigger) SetWorkspaceStream(arg0 tfc_trigger.WorkspacePublisher) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetWorkspaceStream", arg0)
+}
+
+// SetWorkspaceStream indicates an expected call of SetWorkspaceStream.
+func (mr *MockTriggerMockRecorder) SetWorkspaceStream(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkspaceStream", reflect.TypeOf((*MockTrigger)(nil).SetWorkspaceStream), arg0)
 }
 
 // TriggerCleanupEvent mocks base method.

--- a/pkg/tfc_api/api_client.go
+++ b/pkg/tfc_api/api_client.go
@@ -3,14 +3,61 @@ package tfc_api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
 )
+
+// Defaults match Terraform Cloud's documented per-token limit (~30 req/s).
+// When several workspaces fan out concurrently we issue 60+ API calls; without
+// a client-side limiter TFC starts returning 429s and runs end up half-created.
+const (
+	tfcRateLimitRPSKey   = "TFC_RATE_LIMIT_RPS"
+	tfcRateLimitBurstKey = "TFC_RATE_LIMIT_BURST"
+	defaultTFCRateRPS    = 30
+	defaultTFCRateBurst  = 30
+)
+
+func init() {
+	viper.SetDefault(tfcRateLimitRPSKey, defaultTFCRateRPS)
+	viper.SetDefault(tfcRateLimitBurstKey, defaultTFCRateBurst)
+}
+
+// rateLimitedTransport wraps an http.RoundTripper with a token-bucket rate
+// limiter so concurrent callers cooperatively stay under TFC's per-token
+// limit. It is safe for concurrent use.
+type rateLimitedTransport struct {
+	rt      http.RoundTripper
+	limiter *rate.Limiter
+}
+
+func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.limiter.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return t.rt.RoundTrip(req)
+}
+
+// newRateLimitedHTTPClient returns an http.Client whose transport blocks on
+// the supplied limiter. The base transport is a clone of http.DefaultTransport
+// so we keep its connection pooling and dial timeouts. Note: the client has no
+// top-level Timeout — ConfigurationVersions.Upload streams the cloned repo
+// (potentially the whole repo when working_directory is set) and a fixed cap
+// would truncate slow uploads; per-call deadlines flow through context.
+func newRateLimitedHTTPClient(limiter *rate.Limiter) *http.Client {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Client{Transport: &rateLimitedTransport{rt: http.DefaultTransport, limiter: limiter}}
+	}
+	return &http.Client{Transport: &rateLimitedTransport{rt: base.Clone(), limiter: limiter}}
+}
 
 //go:generate mockgen -source api_client.go -destination=../mocks/mock_tfc_api.go -package=mocks github.com/zapier/tfbuddy/pkg/tfc_api
 type ApiClient interface {
@@ -36,17 +83,35 @@ func NewTFCClient() ApiClient {
 		log.Fatal().Msg("TFC_TOKEN not set")
 	}
 
+	rps := tfcRateLimitValue(tfcRateLimitRPSKey, defaultTFCRateRPS)
+	burst := tfcRateLimitValue(tfcRateLimitBurstKey, defaultTFCRateBurst)
+	limiter := rate.NewLimiter(rate.Limit(rps), burst)
+	log.Info().Int("rps", rps).Int("burst", burst).Msg("TFC client rate limit configured")
+
 	config := &tfe.Config{
-		Token: token,
+		Token:      token,
+		HTTPClient: newRateLimitedHTTPClient(limiter),
 	}
 
-	var err error
 	tfcClient, err := tfe.NewClient(config)
 	if err != nil {
 		log.Fatal().Err(err)
 	}
 
 	return &TFCClient{Client: tfcClient}
+}
+
+// tfcRateLimitValue reads a positive int from viper, falling back (with a
+// warning) on any zero/negative value. Garbage strings would already have
+// errored out via viper's automatic env binding.
+func tfcRateLimitValue(key string, fallback int) int {
+	n := viper.GetInt(key)
+	if n < 1 {
+		log.Warn().Str("key", key).Int("value", n).Int("default", fallback).
+			Msg("invalid value, falling back to default")
+		return fallback
+	}
+	return n
 }
 
 func (t *TFCClient) GetRun(ctx context.Context, id string) (*tfe.Run, error) {

--- a/pkg/tfc_api/api_client.go
+++ b/pkg/tfc_api/api_client.go
@@ -13,26 +13,16 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/time/rate"
+
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
-// Defaults match Terraform Cloud's documented per-token limit (~30 req/s).
-// When several workspaces fan out concurrently we issue 60+ API calls; without
-// a client-side limiter TFC starts returning 429s and runs end up half-created.
+// Defaults match TFC's documented per-token limit (~30 req/s).
 const (
-	tfcRateLimitRPSKey   = "TFC_RATE_LIMIT_RPS"
-	tfcRateLimitBurstKey = "TFC_RATE_LIMIT_BURST"
-	defaultTFCRateRPS    = 30
-	defaultTFCRateBurst  = 30
+	defaultTFCRateRPS   = 30
+	defaultTFCRateBurst = 30
 )
 
-func init() {
-	viper.SetDefault(tfcRateLimitRPSKey, defaultTFCRateRPS)
-	viper.SetDefault(tfcRateLimitBurstKey, defaultTFCRateBurst)
-}
-
-// rateLimitedTransport wraps an http.RoundTripper with a token-bucket rate
-// limiter so concurrent callers cooperatively stay under TFC's per-token
-// limit. It is safe for concurrent use.
 type rateLimitedTransport struct {
 	rt      http.RoundTripper
 	limiter *rate.Limiter
@@ -45,12 +35,9 @@ func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return t.rt.RoundTrip(req)
 }
 
-// newRateLimitedHTTPClient returns an http.Client whose transport blocks on
-// the supplied limiter. The base transport is a clone of http.DefaultTransport
-// so we keep its connection pooling and dial timeouts. Note: the client has no
-// top-level Timeout — ConfigurationVersions.Upload streams the cloned repo
-// (potentially the whole repo when working_directory is set) and a fixed cap
-// would truncate slow uploads; per-call deadlines flow through context.
+// newRateLimitedHTTPClient deliberately sets no top-level Timeout —
+// ConfigurationVersions.Upload streams the repo and a fixed cap would
+// truncate slow uploads. Per-call deadlines flow through context.
 func newRateLimitedHTTPClient(limiter *rate.Limiter) *http.Client {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
@@ -83,17 +70,17 @@ func NewTFCClient() ApiClient {
 		log.Fatal().Msg("TFC_TOKEN not set")
 	}
 
-	rps := tfcRateLimitValue(tfcRateLimitRPSKey, defaultTFCRateRPS)
-	burst := tfcRateLimitValue(tfcRateLimitBurstKey, defaultTFCRateBurst)
+	rps := tfcRateLimitValue(config.KeyTFCRateLimitRPS, defaultTFCRateRPS)
+	burst := tfcRateLimitValue(config.KeyTFCRateLimitBurst, defaultTFCRateBurst)
 	limiter := rate.NewLimiter(rate.Limit(rps), burst)
 	log.Info().Int("rps", rps).Int("burst", burst).Msg("TFC client rate limit configured")
 
-	config := &tfe.Config{
+	tfeConfig := &tfe.Config{
 		Token:      token,
 		HTTPClient: newRateLimitedHTTPClient(limiter),
 	}
 
-	tfcClient, err := tfe.NewClient(config)
+	tfcClient, err := tfe.NewClient(tfeConfig)
 	if err != nil {
 		log.Fatal().Err(err)
 	}
@@ -101,9 +88,7 @@ func NewTFCClient() ApiClient {
 	return &TFCClient{Client: tfcClient}
 }
 
-// tfcRateLimitValue reads an int from viper and falls back (with a warning)
-// when the resulting value is invalid for rate limiting, including zero,
-// negative, or otherwise non-usable values.
+// tfcRateLimitValue falls back when the configured value is invalid (zero or negative).
 func tfcRateLimitValue(key string, fallback int) int {
 	n := viper.GetInt(key)
 	if n < 1 {

--- a/pkg/tfc_api/api_client.go
+++ b/pkg/tfc_api/api_client.go
@@ -101,9 +101,9 @@ func NewTFCClient() ApiClient {
 	return &TFCClient{Client: tfcClient}
 }
 
-// tfcRateLimitValue reads a positive int from viper, falling back (with a
-// warning) on any zero/negative value. Garbage strings would already have
-// errored out via viper's automatic env binding.
+// tfcRateLimitValue reads an int from viper and falls back (with a warning)
+// when the resulting value is invalid for rate limiting, including zero,
+// negative, or otherwise non-usable values.
 func tfcRateLimitValue(key string, fallback int) int {
 	n := viper.GetInt(key)
 	if n < 1 {

--- a/pkg/tfc_api/api_client_test.go
+++ b/pkg/tfc_api/api_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,8 +14,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// TestRateLimitedTransport_Sequential verifies the limiter throttles back-to-back
-// requests on the same client.
 func TestRateLimitedTransport_Sequential(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -36,15 +35,12 @@ func TestRateLimitedTransport_Sequential(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// At 5 req/s, burst=1: first call immediate, remaining 5 wait ~200ms each.
+	// 5 req/s, burst=1: first call immediate, remaining 5 wait ~200ms each.
 	if elapsed < 700*time.Millisecond {
 		t.Fatalf("expected rate-limited calls to take >=700ms, got %s", elapsed)
 	}
 }
 
-// TestRateLimitedTransport_ConcurrentSharing verifies multiple goroutines share
-// the same limiter, which is the production scenario when several workspaces
-// fan out concurrently.
 func TestRateLimitedTransport_ConcurrentSharing(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -73,15 +69,11 @@ func TestRateLimitedTransport_ConcurrentSharing(t *testing.T) {
 	wg.Wait()
 	elapsed := time.Since(start)
 
-	// All 6 callers compete for the same bucket: even when fully parallel they
-	// must wait ~200ms per token after the initial burst.
 	if elapsed < 700*time.Millisecond {
 		t.Fatalf("expected concurrent callers to coordinate via the shared limiter (>=700ms), got %s", elapsed)
 	}
 }
 
-// TestRateLimitedTransport_HonorsContextCancel ensures callers can abandon a
-// request blocked on the limiter, e.g. when JetStream cancels processing.
 func TestRateLimitedTransport_HonorsContextCancel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -110,8 +102,8 @@ func TestRateLimitedTransport_HonorsContextCancel(t *testing.T) {
 }
 
 // TestNewRateLimitedHTTPClient_NoHardTimeout guards against re-introducing
-// http.Client.Timeout. ConfigurationVersions.Upload streams the cloned repo
-// so a fixed top-level timeout would truncate slow uploads on large repos.
+// http.Client.Timeout — Upload streams the cloned repo and a fixed cap would
+// truncate slow uploads.
 func TestNewRateLimitedHTTPClient_NoHardTimeout(t *testing.T) {
 	client := newRateLimitedHTTPClient(rate.NewLimiter(rate.Limit(10), 1))
 	if client.Timeout != 0 {
@@ -119,9 +111,8 @@ func TestNewRateLimitedHTTPClient_NoHardTimeout(t *testing.T) {
 	}
 }
 
-// TestTFCRateLimitValue verifies viper-driven defaults and fallback behavior.
 func TestTFCRateLimitValue(t *testing.T) {
-	const key = "TEST_RATE_LIMIT"
+	const key = "test-rate-limit"
 	t.Cleanup(func() { viper.Reset() })
 
 	cases := []struct {
@@ -139,9 +130,10 @@ func TestTFCRateLimitValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			viper.Reset()
 			viper.SetEnvPrefix("TFBUDDY")
+			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 			viper.AutomaticEnv()
 			if tc.setEnv != "" {
-				t.Setenv("TFBUDDY_"+key, tc.setEnv)
+				t.Setenv("TFBUDDY_TEST_RATE_LIMIT", tc.setEnv)
 			}
 			got := tfcRateLimitValue(key, tc.fallback)
 			if got != tc.want {
@@ -151,8 +143,6 @@ func TestTFCRateLimitValue(t *testing.T) {
 	}
 }
 
-// TestRateLimitedTransport_RoundTripIsConcurrencySafe asserts the transport
-// can be hit from many goroutines without panics or data races (run with -race).
 func TestRateLimitedTransport_RoundTripIsConcurrencySafe(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/tfc_api/api_client_test.go
+++ b/pkg/tfc_api/api_client_test.go
@@ -1,0 +1,188 @@
+package tfc_api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"golang.org/x/time/rate"
+)
+
+// TestRateLimitedTransport_Sequential verifies the limiter throttles back-to-back
+// requests on the same client.
+func TestRateLimitedTransport_Sequential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	limiter := rate.NewLimiter(rate.Limit(5), 1)
+	client := newRateLimitedHTTPClient(limiter)
+
+	const total = 6
+	start := time.Now()
+	for i := 0; i < total; i++ {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+	elapsed := time.Since(start)
+
+	// At 5 req/s, burst=1: first call immediate, remaining 5 wait ~200ms each.
+	if elapsed < 700*time.Millisecond {
+		t.Fatalf("expected rate-limited calls to take >=700ms, got %s", elapsed)
+	}
+}
+
+// TestRateLimitedTransport_ConcurrentSharing verifies multiple goroutines share
+// the same limiter, which is the production scenario when several workspaces
+// fan out concurrently.
+func TestRateLimitedTransport_ConcurrentSharing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	limiter := rate.NewLimiter(rate.Limit(5), 1)
+	client := newRateLimitedHTTPClient(limiter)
+
+	const total = 6
+	var wg sync.WaitGroup
+	wg.Add(total)
+	start := time.Now()
+	for i := 0; i < total; i++ {
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// All 6 callers compete for the same bucket: even when fully parallel they
+	// must wait ~200ms per token after the initial burst.
+	if elapsed < 700*time.Millisecond {
+		t.Fatalf("expected concurrent callers to coordinate via the shared limiter (>=700ms), got %s", elapsed)
+	}
+}
+
+// TestRateLimitedTransport_HonorsContextCancel ensures callers can abandon a
+// request blocked on the limiter, e.g. when JetStream cancels processing.
+func TestRateLimitedTransport_HonorsContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	limiter := rate.NewLimiter(rate.Limit(0.1), 1)
+	transport := &rateLimitedTransport{rt: http.DefaultTransport, limiter: limiter}
+
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("priming bucket failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+
+	start := time.Now()
+	_, err := transport.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected context-cancelled error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("RoundTrip should have returned promptly after cancel, took %s", elapsed)
+	}
+}
+
+// TestNewRateLimitedHTTPClient_NoHardTimeout guards against re-introducing
+// http.Client.Timeout. ConfigurationVersions.Upload streams the cloned repo
+// so a fixed top-level timeout would truncate slow uploads on large repos.
+func TestNewRateLimitedHTTPClient_NoHardTimeout(t *testing.T) {
+	client := newRateLimitedHTTPClient(rate.NewLimiter(rate.Limit(10), 1))
+	if client.Timeout != 0 {
+		t.Fatalf("expected zero http.Client.Timeout, got %s", client.Timeout)
+	}
+}
+
+// TestTFCRateLimitValue verifies viper-driven defaults and fallback behavior.
+func TestTFCRateLimitValue(t *testing.T) {
+	const key = "TEST_RATE_LIMIT"
+	t.Cleanup(func() { viper.Reset() })
+
+	cases := []struct {
+		name     string
+		setEnv   string
+		fallback int
+		want     int
+	}{
+		{"unset returns fallback", "", 30, 30},
+		{"valid value parsed", "42", 30, 42},
+		{"zero falls back", "0", 30, 30},
+		{"negative falls back", "-7", 30, 30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			viper.SetEnvPrefix("TFBUDDY")
+			viper.AutomaticEnv()
+			if tc.setEnv != "" {
+				t.Setenv("TFBUDDY_"+key, tc.setEnv)
+			}
+			got := tfcRateLimitValue(key, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("tfcRateLimitValue(%q)=%d, want %d", tc.setEnv, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRateLimitedTransport_RoundTripIsConcurrencySafe asserts the transport
+// can be hit from many goroutines without panics or data races (run with -race).
+func TestRateLimitedTransport_RoundTripIsConcurrencySafe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	transport := &rateLimitedTransport{
+		rt:      http.DefaultTransport,
+		limiter: rate.NewLimiter(rate.Inf, 1),
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	var done int32
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Errorf("RoundTrip error: %v", err)
+				return
+			}
+			resp.Body.Close()
+			atomic.AddInt32(&done, 1)
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&done); got != goroutines {
+		t.Fatalf("expected %d successful round trips, got %d", goroutines, got)
+	}
+}

--- a/pkg/tfc_trigger/interfaces.go
+++ b/pkg/tfc_trigger/interfaces.go
@@ -18,6 +18,7 @@ type Trigger interface {
 	GetTriggerSource() TriggerSource
 	GetWorkspace() string
 	GetVcsProvider() string
+	SetWorkspaceStream(WorkspacePublisher)
 }
 type TriggerAction int
 type TriggerSource int

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -164,7 +164,7 @@ type TFCWorkspace struct {
 }
 
 func getProjectConfigFile(ctx context.Context, gl vcs.GitClient, trigger *TFCTrigger) (*ProjectConfig, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getProjectConfigFile")
+	ctx, span := otel.Tracer(trigger.tracerName()).Start(ctx, "getProjectConfigFile")
 	defer span.End()
 
 	branches := []string{trigger.GetBranch(), "master", "main"}

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -88,6 +88,24 @@ type TFCTrigger struct {
 	gl        vcs.GitClient
 	tfc       tfc_api.ApiClient
 	runstream runstream.StreamClient
+	// workspaceStream, when set, makes TriggerTFCEvents fan out one NATS
+	// message per workspace instead of running them inline. The MR/PR webhook
+	// flow uses this so the JetStream subscriber ACKs well within AckWait
+	// regardless of how many workspaces an MR touches.
+	workspaceStream WorkspacePublisher
+}
+
+// WorkspacePublisher is the minimum surface area a fan-out target needs. The
+// concrete implementation is *WorkspaceStream; tests use a fake.
+type WorkspacePublisher interface {
+	Publish(ctx context.Context, msg *WorkspaceTriggerMsg) error
+}
+
+// SetWorkspaceStream wires a publisher onto an existing trigger. Used by the
+// hooks layer at construction time and by tests; safe to leave nil to keep
+// the legacy synchronous behavior (e.g. for unit tests of the inner loop).
+func (t *TFCTrigger) SetWorkspaceStream(s WorkspacePublisher) {
+	t.workspaceStream = s
 }
 
 type TFCTriggerOptions struct {
@@ -377,6 +395,16 @@ func (t *TFCTrigger) cloneGitRepo(ctx context.Context, mr vcs.MR) (vcs.GitRepo, 
 	}
 	return repo, nil
 }
+
+// TriggerTFCEvents validates an MR/PR (or comment) trigger and dispatches one
+// run per workspace it touches. When a WorkspacePublisher is wired in (the
+// production path), each workspace is enqueued for the workspace worker to
+// process; otherwise we fall back to the inline flow used by tests.
+//
+// Validation failures (allow/deny list, no changes, project missing
+// .tfbuddy.yaml) are returned synchronously so comment-triggered callers can
+// surface them immediately. Per-run failures land in the workspace worker,
+// which posts them to the MR/PR directly.
 func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspaces, error) {
 	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "TriggerTFCEvents")
 	defer span.End()
@@ -389,64 +417,108 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 	if err != nil {
 		return nil, fmt.Errorf("could not read triggered workspaces. %w", err)
 	}
-	workspaceStatus := &TriggeredTFCWorkspaces{
-		Errored:  make([]*ErroredWorkspace, 0),
-		Executed: make([]string, 0),
-	}
-	if len(triggeredWorkspaces) > 0 {
-
-		repo, err := t.cloneGitRepo(ctx, mr)
-		if err != nil {
-			return nil, err
+	if len(triggeredWorkspaces) == 0 {
+		if t.GetTriggerSource() == CommentTrigger {
+			log.Error().Err(ErrNoChangesDetected)
+			t.postUpdate(ctx, ErrNoChangesDetected.Error())
+			return nil, nil
 		}
-		defer os.Remove(repo.GetLocalDirectory())
-
-		modifiedWSMap, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
-		if err != nil {
-			err = t.postUpdate(ctx, ":warning: Could not identify modified workspaces on target branch. Please review the plan carefully for unrelated changes.")
-			if err != nil {
-				log.Error().Err(err).Msg("could not update MR with message")
-			}
-		}
-		for _, cfgWS := range triggeredWorkspaces {
-			// check allow / deny lists
-			if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
-				log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: "Ignoring workspace, because of allow/deny list.",
-				})
-				continue
-			}
-			if _, ok := modifiedWSMap[cfgWS.Name]; ok {
-				log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Strs("triggerDirs", cfgWS.TriggerDirs).Msg("Blocking workspace: relevant paths modified on target branch.")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs),
-				})
-				continue
-			}
-			if err := t.triggerRunForWorkspace(ctx, cfgWS, mr, repo.GetLocalDirectory()); err != nil {
-				log.Error().Err(err).Msg("could not trigger Run for Workspace")
-				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-					Name:  cfgWS.Name,
-					Error: fmt.Sprintf("could not trigger Run for Workspace. %v", err),
-				})
-				continue
-			}
-			workspaceStatus.Executed = append(workspaceStatus.Executed, cfgWS.Name)
-		}
-
-	} else if t.GetTriggerSource() == CommentTrigger {
-		log.Error().Err(ErrNoChangesDetected)
-		t.postUpdate(ctx, ErrNoChangesDetected.Error())
-		return nil, nil
-
-	} else {
 		log.Debug().Msg("No Terraform changes found in changeset.")
 		return nil, nil
 	}
 
+	if t.workspaceStream != nil {
+		return t.enqueueWorkspaceTriggers(ctx, triggeredWorkspaces)
+	}
+
+	return t.runWorkspacesInline(ctx, mr, triggeredWorkspaces)
+}
+
+// enqueueWorkspaceTriggers fans out one NATS message per workspace. Cheap
+// validation (allow/deny list) runs synchronously so comment users get
+// immediate feedback; the heavier per-workspace work — clone, target-branch
+// check, lock check, discussion creation, TFC run — happens in the workspace
+// worker, where each delivery has its own JetStream AckWait window.
+func (t *TFCTrigger) enqueueWorkspaceTriggers(ctx context.Context, triggeredWorkspaces []*TFCWorkspace) (*TriggeredTFCWorkspaces, error) {
+	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "enqueueWorkspaceTriggers")
+	defer span.End()
+
+	status := &TriggeredTFCWorkspaces{
+		Errored:  make([]*ErroredWorkspace, 0),
+		Executed: make([]string, 0),
+	}
+	for _, cfgWS := range triggeredWorkspaces {
+		if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
+			log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
+			status.Errored = append(status.Errored, &ErroredWorkspace{
+				Name:  cfgWS.Name,
+				Error: "Ignoring workspace, because of allow/deny list.",
+			})
+			continue
+		}
+
+		msg := &WorkspaceTriggerMsg{Opts: *t.cfg, Workspace: *cfgWS}
+		if err := t.workspaceStream.Publish(ctx, msg); err != nil {
+			log.Error().Err(err).Str("ws", cfgWS.Name).Msg("could not enqueue workspace trigger")
+			status.Errored = append(status.Errored, &ErroredWorkspace{
+				Name:  cfgWS.Name,
+				Error: fmt.Sprintf("could not enqueue workspace trigger. %v", err),
+			})
+			continue
+		}
+		status.Executed = append(status.Executed, cfgWS.Name)
+	}
+	log.Debug().Int("triggered", len(status.Executed)).Int("errored", len(status.Errored)).
+		Msg("workspace triggers enqueued")
+	return status, nil
+}
+
+// runWorkspacesInline preserves the original synchronous behavior, used when
+// no workspace stream is configured (e.g. unit tests of the inner loop).
+func (t *TFCTrigger) runWorkspacesInline(ctx context.Context, mr vcs.DetailedMR, triggeredWorkspaces []*TFCWorkspace) (*TriggeredTFCWorkspaces, error) {
+	workspaceStatus := &TriggeredTFCWorkspaces{
+		Errored:  make([]*ErroredWorkspace, 0),
+		Executed: make([]string, 0),
+	}
+	repo, err := t.cloneGitRepo(ctx, mr)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(repo.GetLocalDirectory())
+
+	modifiedWSMap, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
+	if err != nil {
+		if err := t.postUpdate(ctx, ":warning: Could not identify modified workspaces on target branch. Please review the plan carefully for unrelated changes."); err != nil {
+			log.Error().Err(err).Msg("could not update MR with message")
+		}
+	}
+	for _, cfgWS := range triggeredWorkspaces {
+		if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
+			log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
+			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
+				Name:  cfgWS.Name,
+				Error: "Ignoring workspace, because of allow/deny list.",
+			})
+			continue
+		}
+		if _, ok := modifiedWSMap[cfgWS.Name]; ok {
+			log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Strs("triggerDirs", cfgWS.TriggerDirs).Msg("Blocking workspace: relevant paths modified on target branch.")
+			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
+				Name:  cfgWS.Name,
+				Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs),
+			})
+			continue
+		}
+		if err := t.triggerRunForWorkspace(ctx, cfgWS, mr, repo.GetLocalDirectory()); err != nil {
+			log.Error().Err(err).Msg("could not trigger Run for Workspace")
+			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
+				Name:  cfgWS.Name,
+				Error: fmt.Sprintf("could not trigger Run for Workspace. %v", err),
+			})
+			continue
+		}
+		workspaceStatus.Executed = append(workspaceStatus.Executed, cfgWS.Name)
+	}
 	return workspaceStatus, nil
 }
 
@@ -649,9 +721,13 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	if err != nil {
 		return fmt.Errorf("could not create MR discussion thread for TFC run status updates. %w", err)
 	}
-	t.SetMergeRequestDiscussionID(disc.GetDiscussionID())
+	// Discussion + root note IDs are local to this invocation rather than
+	// stashed on t.cfg, so concurrent triggers (one goroutine per workspace
+	// in the fan-out worker) cannot race on the shared struct.
+	discussionID := disc.GetDiscussionID()
+	var rootNoteID int64
 	if len(disc.GetMRNotes()) > 0 {
-		t.SetMergeRequestRootNoteID(disc.GetMRNotes()[0].GetNoteID())
+		rootNoteID = disc.GetMRNotes()[0].GetNoteID()
 	} else {
 		log.Debug().Msg("No MR Notes found")
 	}
@@ -679,10 +755,10 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 		Bool("speculative", run.ConfigurationVersion.Speculative).
 		Msg("created TFC run")
 
-	return t.publishRunToStream(ctx, run, cfgWS)
+	return t.publishRunToStream(ctx, run, cfgWS, discussionID, rootNoteID)
 }
 
-func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS *TFCWorkspace) error {
+func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS *TFCWorkspace, discussionID string, rootNoteID int64) error {
 	ctx, span := otel.Tracer("TFC").Start(ctx, "publishRunToStream")
 	defer span.End()
 
@@ -695,8 +771,8 @@ func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS
 		CommitSHA:                            t.GetCommitSHA(),
 		MergeRequestProjectNameWithNamespace: t.GetProjectNameWithNamespace(),
 		MergeRequestIID:                      t.GetMergeRequestIID(),
-		DiscussionID:                         t.GetMergeRequestDiscussionID(),
-		RootNoteID:                           t.GetMergeRequestRootNoteID(),
+		DiscussionID:                         discussionID,
+		RootNoteID:                           rootNoteID,
 		VcsProvider:                          t.GetVcsProvider(),
 		AutoMerge:                            cfgWS.AutoMerge,
 	}

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -214,6 +214,24 @@ func (t *TFCTrigger) GetWorkspace() string {
 	return t.cfg.Workspace
 }
 
+// tracerName derives an OpenTelemetry tracer name from the VCS provider
+// driving this trigger. TFCTrigger is shared between the GitLab and GitHub
+// stream workers, so a hard-coded provider name would mislabel half of the
+// traces; falling back to a provider-agnostic name keeps spans honest when
+// VcsProvider is unset (older callers and unit tests).
+func (t *TFCTrigger) tracerName() string {
+	switch t.cfg.VcsProvider {
+	case "github":
+		return "GithubHandler"
+	case "gitlab":
+		return "GitlabHandler"
+	case "bitbucket":
+		return "BitbucketHandler"
+	default:
+		return "TFCTrigger"
+	}
+}
+
 // predefined errors
 var (
 	ErrWorkspaceNotDefined = errors.New("the workspace is not defined in " + ProjectConfigFilename)
@@ -285,7 +303,7 @@ func (t *TFCTrigger) getLockingMR(ctx context.Context, workspace string) string 
 }
 
 func (t *TFCTrigger) getTriggeredWorkspaces(ctx context.Context, modifiedFiles []string) ([]*TFCWorkspace, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getTriggeredWorkspaces")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "getTriggeredWorkspaces")
 	defer span.End()
 
 	cfg, err := getProjectConfigFile(ctx, t.gl, t)
@@ -329,7 +347,7 @@ type TriggeredTFCWorkspaces struct {
 }
 
 func (t *TFCTrigger) getModifiedWorkspacesOnTargetBranch(ctx context.Context, mr vcs.MR, repo vcs.GitRepo, triggeredWorkspaces []*TFCWorkspace) (map[string]struct{}, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getModifiedWorkspacesOnTargetBranch")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "getModifiedWorkspacesOnTargetBranch")
 	defer span.End()
 
 	modifiedWSMap := make(map[string]struct{}, 0)
@@ -367,7 +385,7 @@ func (t *TFCTrigger) getModifiedWorkspacesOnTargetBranch(ctx context.Context, mr
 	return modifiedWSMap, err
 }
 func (t *TFCTrigger) getTriggeredWorkspacesForRequest(ctx context.Context, mr vcs.MR) ([]*TFCWorkspace, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "getTriggeredWorkspacesForRequest")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "getTriggeredWorkspacesForRequest")
 	defer span.End()
 
 	mrModifiedFiles, err := t.gl.GetMergeRequestModifiedFiles(ctx, mr.GetInternalID(), t.GetProjectNameWithNamespace())
@@ -381,7 +399,7 @@ func (t *TFCTrigger) getTriggeredWorkspacesForRequest(ctx context.Context, mr vc
 
 // cloneGitRepo will clone the git repo for a specific MR and returns the temp path to be cleaned up later
 func (t *TFCTrigger) cloneGitRepo(ctx context.Context, mr vcs.MR) (vcs.GitRepo, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "cloneGitRepo")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "cloneGitRepo")
 	defer span.End()
 
 	safeProj := strings.ReplaceAll(t.GetProjectNameWithNamespace(), "/", "-")
@@ -406,7 +424,7 @@ func (t *TFCTrigger) cloneGitRepo(ctx context.Context, mr vcs.MR) (vcs.GitRepo, 
 // surface them immediately. Per-run failures land in the workspace worker,
 // which posts them to the MR/PR directly.
 func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspaces, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "TriggerTFCEvents")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "TriggerTFCEvents")
 	defer span.End()
 
 	mr, err := t.gl.GetMergeRequest(ctx, t.GetMergeRequestIID(), t.GetProjectNameWithNamespace())
@@ -440,7 +458,7 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 // check, lock check, discussion creation, TFC run — happens in the workspace
 // worker, where each delivery has its own JetStream AckWait window.
 func (t *TFCTrigger) enqueueWorkspaceTriggers(ctx context.Context, triggeredWorkspaces []*TFCWorkspace) (*TriggeredTFCWorkspaces, error) {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "enqueueWorkspaceTriggers")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "enqueueWorkspaceTriggers")
 	defer span.End()
 
 	status := &TriggeredTFCWorkspaces{
@@ -484,7 +502,11 @@ func (t *TFCTrigger) runWorkspacesInline(ctx context.Context, mr vcs.DetailedMR,
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(repo.GetLocalDirectory())
+	defer func() {
+		if err := os.RemoveAll(repo.GetLocalDirectory()); err != nil {
+			log.Error().Err(err).Str("path", repo.GetLocalDirectory()).Msg("could not remove cloned repository directory")
+		}
+	}()
 
 	modifiedWSMap, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
 	if err != nil {
@@ -523,7 +545,7 @@ func (t *TFCTrigger) runWorkspacesInline(ctx context.Context, mr vcs.DetailedMR,
 }
 
 func (t *TFCTrigger) TriggerCleanupEvent(ctx context.Context) error {
-	ctx, span := otel.Tracer("GitlabHandler").Start(ctx, "TriggerCleanupEvent")
+	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "TriggerCleanupEvent")
 	defer span.End()
 
 	mr, err := t.gl.GetMergeRequest(ctx, t.GetMergeRequestIID(), t.GetProjectNameWithNamespace())

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +23,10 @@ import (
 	"github.com/zapier/tfbuddy/pkg/utils"
 	"github.com/zapier/tfbuddy/pkg/vcs"
 )
+
+// MRCommentTargetBranchEvalFailed is the MR-level warning when analysis cannot
+// determine whether the target branch modified workspace-relevant paths.
+const MRCommentTargetBranchEvalFailed = ":warning: Could not identify modified workspaces on target branch. Please review the plan carefully for unrelated changes."
 
 const (
 	ApplyAction TriggerAction = iota
@@ -88,22 +91,15 @@ type TFCTrigger struct {
 	gl        vcs.GitClient
 	tfc       tfc_api.ApiClient
 	runstream runstream.StreamClient
-	// workspaceStream, when set, makes TriggerTFCEvents fan out one NATS
-	// message per workspace instead of running them inline. The MR/PR webhook
-	// flow uses this so the JetStream subscriber ACKs well within AckWait
-	// regardless of how many workspaces an MR touches.
+	// workspaceStream, when set, fans out one message per workspace instead
+	// of running them inline. Nil keeps the legacy synchronous behavior.
 	workspaceStream WorkspacePublisher
 }
 
-// WorkspacePublisher is the minimum surface area a fan-out target needs. The
-// concrete implementation is *WorkspaceStream; tests use a fake.
 type WorkspacePublisher interface {
 	Publish(ctx context.Context, msg *WorkspaceTriggerMsg) error
 }
 
-// SetWorkspaceStream wires a publisher onto an existing trigger. Used by the
-// hooks layer at construction time and by tests; safe to leave nil to keep
-// the legacy synchronous behavior (e.g. for unit tests of the inner loop).
 func (t *TFCTrigger) SetWorkspaceStream(s WorkspacePublisher) {
 	t.workspaceStream = s
 }
@@ -118,10 +114,14 @@ type TFCTriggerOptions struct {
 	MergeRequestRootNoteID   int64
 	TriggerSource            TriggerSource
 	VcsProvider              string
-	Workspace                string `short:"w" long:"workspace" description:"A specific terraform Workspace to use" required:"false"`
-	TFVersion                string `short:"v" long:"tf_version" description:"A specific terraform version to use" required:"false"`
-	Target                   string `short:"t" long:"target" description:"A specific terraform target to use" required:"false"`
-	AllowEmptyRun            bool   `short:"e" long:"allow_empty_run" description:"A specific terraform AllowEmptyRun" required:"false"`
+	// DeliveryID is the upstream webhook delivery ID (X-GitHub-Delivery /
+	// X-Gitlab-Event-UUID). Used as the JetStream dedup anchor so retriggers
+	// are not silently dropped within the dedup window.
+	DeliveryID    string
+	Workspace     string `short:"w" long:"workspace" description:"A specific terraform Workspace to use" required:"false"`
+	TFVersion     string `short:"v" long:"tf_version" description:"A specific terraform version to use" required:"false"`
+	Target        string `short:"t" long:"target" description:"A specific terraform target to use" required:"false"`
+	AllowEmptyRun bool   `short:"e" long:"allow_empty_run" description:"A specific terraform AllowEmptyRun" required:"false"`
 }
 
 func NewTFCTriggerConfig(opts *TFCTriggerOptions) (*TFCTriggerOptions, error) {
@@ -214,19 +214,14 @@ func (t *TFCTrigger) GetWorkspace() string {
 	return t.cfg.Workspace
 }
 
-// tracerName derives an OpenTelemetry tracer name from the VCS provider
-// driving this trigger. TFCTrigger is shared between the GitLab and GitHub
-// stream workers, so a hard-coded provider name would mislabel half of the
-// traces; falling back to a provider-agnostic name keeps spans honest when
-// VcsProvider is unset (older callers and unit tests).
+// tracerName derives the OpenTelemetry tracer name from VcsProvider so spans
+// are correctly labeled regardless of which stream worker invoked this trigger.
 func (t *TFCTrigger) tracerName() string {
 	switch t.cfg.VcsProvider {
 	case "github":
 		return "GithubHandler"
 	case "gitlab":
 		return "GitlabHandler"
-	case "bitbucket":
-		return "BitbucketHandler"
 	default:
 		return "TFCTrigger"
 	}
@@ -403,7 +398,7 @@ func (t *TFCTrigger) cloneGitRepo(ctx context.Context, mr vcs.MR) (vcs.GitRepo, 
 	defer span.End()
 
 	safeProj := strings.ReplaceAll(t.GetProjectNameWithNamespace(), "/", "-")
-	cloneDir, err := ioutil.TempDir("", fmt.Sprintf("%s-%d-*", safeProj, t.GetMergeRequestIID()))
+	cloneDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%d-*", safeProj, t.GetMergeRequestIID()))
 	if err != nil {
 		return nil, fmt.Errorf("could not create tmp directory. %w", err)
 	}
@@ -414,22 +409,16 @@ func (t *TFCTrigger) cloneGitRepo(ctx context.Context, mr vcs.MR) (vcs.GitRepo, 
 	return repo, nil
 }
 
-// TriggerTFCEvents validates an MR/PR (or comment) trigger and dispatches one
-// run per workspace it touches. When a WorkspacePublisher is wired in (the
-// production path), each workspace is enqueued for the workspace worker to
-// process; otherwise we fall back to the inline flow used by tests.
-//
-// Validation failures (allow/deny list, no changes, project missing
-// .tfbuddy.yaml) are returned synchronously so comment-triggered callers can
-// surface them immediately. Per-run failures land in the workspace worker,
-// which posts them to the MR/PR directly.
+// TriggerTFCEvents dispatches one run per touched workspace. The clone and
+// target-branch evaluation happen once per delivery so the fan-out path
+// doesn't redo MR-level work in every worker.
 func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspaces, error) {
 	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "TriggerTFCEvents")
 	defer span.End()
 
 	mr, err := t.gl.GetMergeRequest(ctx, t.GetMergeRequestIID(), t.GetProjectNameWithNamespace())
 	if err != nil {
-		return nil, fmt.Errorf("could not read MergeRequest data from Gitlab API. %w", err)
+		return nil, fmt.Errorf("could not read MergeRequest data from VCS API: %w", err)
 	}
 	triggeredWorkspaces, err := t.getTriggeredWorkspacesForRequest(ctx, mr)
 	if err != nil {
@@ -437,67 +426,14 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 	}
 	if len(triggeredWorkspaces) == 0 {
 		if t.GetTriggerSource() == CommentTrigger {
-			log.Error().Err(ErrNoChangesDetected)
+			log.Error().Err(ErrNoChangesDetected).Msg("No Terraform changes found in changeset.")
 			t.postUpdate(ctx, ErrNoChangesDetected.Error())
-			return nil, nil
+		} else {
+			log.Debug().Msg("No Terraform changes found in changeset.")
 		}
-		log.Debug().Msg("No Terraform changes found in changeset.")
-		return nil, nil
+		return &TriggeredTFCWorkspaces{}, nil
 	}
 
-	if t.workspaceStream != nil {
-		return t.enqueueWorkspaceTriggers(ctx, triggeredWorkspaces)
-	}
-
-	return t.runWorkspacesInline(ctx, mr, triggeredWorkspaces)
-}
-
-// enqueueWorkspaceTriggers fans out one NATS message per workspace. Cheap
-// validation (allow/deny list) runs synchronously so comment users get
-// immediate feedback; the heavier per-workspace work — clone, target-branch
-// check, lock check, discussion creation, TFC run — happens in the workspace
-// worker, where each delivery has its own JetStream AckWait window.
-func (t *TFCTrigger) enqueueWorkspaceTriggers(ctx context.Context, triggeredWorkspaces []*TFCWorkspace) (*TriggeredTFCWorkspaces, error) {
-	ctx, span := otel.Tracer(t.tracerName()).Start(ctx, "enqueueWorkspaceTriggers")
-	defer span.End()
-
-	status := &TriggeredTFCWorkspaces{
-		Errored:  make([]*ErroredWorkspace, 0),
-		Executed: make([]string, 0),
-	}
-	for _, cfgWS := range triggeredWorkspaces {
-		if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
-			log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
-			status.Errored = append(status.Errored, &ErroredWorkspace{
-				Name:  cfgWS.Name,
-				Error: "Ignoring workspace, because of allow/deny list.",
-			})
-			continue
-		}
-
-		msg := &WorkspaceTriggerMsg{Opts: *t.cfg, Workspace: *cfgWS}
-		if err := t.workspaceStream.Publish(ctx, msg); err != nil {
-			log.Error().Err(err).Str("ws", cfgWS.Name).Msg("could not enqueue workspace trigger")
-			status.Errored = append(status.Errored, &ErroredWorkspace{
-				Name:  cfgWS.Name,
-				Error: fmt.Sprintf("could not enqueue workspace trigger. %v", err),
-			})
-			continue
-		}
-		status.Executed = append(status.Executed, cfgWS.Name)
-	}
-	log.Debug().Int("triggered", len(status.Executed)).Int("errored", len(status.Errored)).
-		Msg("workspace triggers enqueued")
-	return status, nil
-}
-
-// runWorkspacesInline preserves the original synchronous behavior, used when
-// no workspace stream is configured (e.g. unit tests of the inner loop).
-func (t *TFCTrigger) runWorkspacesInline(ctx context.Context, mr vcs.DetailedMR, triggeredWorkspaces []*TFCWorkspace) (*TriggeredTFCWorkspaces, error) {
-	workspaceStatus := &TriggeredTFCWorkspaces{
-		Errored:  make([]*ErroredWorkspace, 0),
-		Executed: make([]string, 0),
-	}
 	repo, err := t.cloneGitRepo(ctx, mr)
 	if err != nil {
 		return nil, err
@@ -508,40 +444,73 @@ func (t *TFCTrigger) runWorkspacesInline(ctx context.Context, mr vcs.DetailedMR,
 		}
 	}()
 
-	modifiedWSMap, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
+	blocked, err := t.getModifiedWorkspacesOnTargetBranch(ctx, mr, repo, triggeredWorkspaces)
 	if err != nil {
-		if err := t.postUpdate(ctx, ":warning: Could not identify modified workspaces on target branch. Please review the plan carefully for unrelated changes."); err != nil {
+		if err := t.postUpdate(ctx, MRCommentTargetBranchEvalFailed); err != nil {
 			log.Error().Err(err).Msg("could not update MR with message")
 		}
 	}
-	for _, cfgWS := range triggeredWorkspaces {
-		if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
-			log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
-			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-				Name:  cfgWS.Name,
+
+	dispatch := t.runInline(mr, repo)
+	if t.workspaceStream != nil {
+		dispatch = t.enqueue
+	}
+	return t.dispatchWorkspaces(ctx, triggeredWorkspaces, blocked, dispatch), nil
+}
+
+// workspaceDispatchFn runs (inline) or enqueues (fan-out) a single workspace.
+// Returning an error puts the workspace into status.Errored verbatim.
+type workspaceDispatchFn func(ctx context.Context, ws *TFCWorkspace) error
+
+func (t *TFCTrigger) dispatchWorkspaces(ctx context.Context, workspaces []*TFCWorkspace, blocked map[string]struct{}, dispatch workspaceDispatchFn) *TriggeredTFCWorkspaces {
+	status := &TriggeredTFCWorkspaces{
+		Errored:  make([]*ErroredWorkspace, 0),
+		Executed: make([]string, 0),
+	}
+	for _, ws := range workspaces {
+		if !isWorkspaceAllowed(t.appCfg, ws.Name, ws.Organization) {
+			log.Info().Str("ws", ws.Name).Msg("Ignoring workspace, because of allow/deny list.")
+			status.Errored = append(status.Errored, &ErroredWorkspace{
+				Name:  ws.Name,
 				Error: "Ignoring workspace, because of allow/deny list.",
 			})
 			continue
 		}
-		if _, ok := modifiedWSMap[cfgWS.Name]; ok {
-			log.Info().Str("ws", cfgWS.Name).Str("dir", cfgWS.Dir).Strs("triggerDirs", cfgWS.TriggerDirs).Msg("Blocking workspace: relevant paths modified on target branch.")
-			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-				Name:  cfgWS.Name,
-				Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", cfgWS.Dir, cfgWS.TriggerDirs),
+		if _, ok := blocked[ws.Name]; ok {
+			log.Info().Str("ws", ws.Name).Str("dir", ws.Dir).Strs("triggerDirs", ws.TriggerDirs).
+				Msg("Blocking workspace: relevant paths modified on target branch.")
+			status.Errored = append(status.Errored, &ErroredWorkspace{
+				Name:  ws.Name,
+				Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", ws.Dir, ws.TriggerDirs),
 			})
 			continue
 		}
-		if err := t.triggerRunForWorkspace(ctx, cfgWS, mr, repo.GetLocalDirectory()); err != nil {
-			log.Error().Err(err).Msg("could not trigger Run for Workspace")
-			workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
-				Name:  cfgWS.Name,
-				Error: fmt.Sprintf("could not trigger Run for Workspace. %v", err),
-			})
+		if err := dispatch(ctx, ws); err != nil {
+			status.Errored = append(status.Errored, &ErroredWorkspace{Name: ws.Name, Error: err.Error()})
 			continue
 		}
-		workspaceStatus.Executed = append(workspaceStatus.Executed, cfgWS.Name)
+		status.Executed = append(status.Executed, ws.Name)
 	}
-	return workspaceStatus, nil
+	return status
+}
+
+func (t *TFCTrigger) runInline(mr vcs.DetailedMR, repo vcs.GitRepo) workspaceDispatchFn {
+	return func(ctx context.Context, ws *TFCWorkspace) error {
+		if err := t.triggerRunForWorkspace(ctx, ws, mr, repo.GetLocalDirectory()); err != nil {
+			log.Error().Err(err).Str("ws", ws.Name).Msg("could not trigger Run for Workspace")
+			return fmt.Errorf("could not trigger Run for Workspace. %w", err)
+		}
+		return nil
+	}
+}
+
+func (t *TFCTrigger) enqueue(ctx context.Context, ws *TFCWorkspace) error {
+	msg := &WorkspaceTriggerMsg{Opts: *t.cfg, Workspace: *ws}
+	if err := t.workspaceStream.Publish(ctx, msg); err != nil {
+		log.Error().Err(err).Str("ws", ws.Name).Msg("could not enqueue workspace trigger")
+		return fmt.Errorf("could not enqueue workspace trigger. %w", err)
+	}
+	return nil
 }
 
 func (t *TFCTrigger) TriggerCleanupEvent(ctx context.Context) error {
@@ -550,7 +519,7 @@ func (t *TFCTrigger) TriggerCleanupEvent(ctx context.Context) error {
 
 	mr, err := t.gl.GetMergeRequest(ctx, t.GetMergeRequestIID(), t.GetProjectNameWithNamespace())
 	if err != nil {
-		return fmt.Errorf("could not read MergeRequest data from Gitlab API. %w", err)
+		return fmt.Errorf("could not read MergeRequest data from VCS API: %w", err)
 	}
 	triggeredWorkspaces, err := t.getTriggeredWorkspacesForRequest(ctx, mr)
 	if err != nil {
@@ -743,9 +712,7 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	if err != nil {
 		return fmt.Errorf("could not create MR discussion thread for TFC run status updates. %w", err)
 	}
-	// Discussion + root note IDs are local to this invocation rather than
-	// stashed on t.cfg, so concurrent triggers (one goroutine per workspace
-	// in the fan-out worker) cannot race on the shared struct.
+	// Keep these local — concurrent fan-out workers must not share state via t.cfg.
 	discussionID := disc.GetDiscussionID()
 	var rootNoteID int64
 	if len(disc.GetMRNotes()) > 0 {

--- a/pkg/tfc_trigger/workspace_stream.go
+++ b/pkg/tfc_trigger/workspace_stream.go
@@ -1,0 +1,148 @@
+package tfc_trigger
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog/log"
+	"github.com/sl1pm4t/gongs"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// WorkspaceTriggerStreamName is the JetStream that carries one message per
+// workspace that needs a TFC run dispatched. Each MR/PR event fans out into
+// these messages so the upstream hook subscriber can ACK quickly and avoid
+// JetStream redelivering when the batch has many workspaces.
+const (
+	WorkspaceTriggerStreamName = "TFBUDDY_WORKSPACE_TRIGGERS"
+	workspaceTriggerSubject    = "TFBUDDY_WORKSPACE_TRIGGERS.dispatch"
+	workspaceTriggerQueueName  = "tfbuddy_workspace_trigger_worker"
+
+	// Sized to match HOOKS/RUN_EVENTS so a noisy day cannot push older
+	// streams off the broker. At ~1KB per msg, 10240 msgs is ~10MB peak.
+	workspaceStreamMaxMsgs = 10240
+
+	// A workspace trigger that hasn't been picked up within an hour is stale
+	// (the user has likely re-triggered or the MR is gone). Dropping it is
+	// safer than dispatching a run against an old commit.
+	workspaceStreamMaxAge = time.Hour
+)
+
+// WorkspaceTriggerMsg is the unit of work consumed by WorkspaceTriggerWorker.
+// It contains everything required to drive a single workspace's TFC run from
+// scratch, with no shared state across workspaces.
+type WorkspaceTriggerMsg struct {
+	Opts      TFCTriggerOptions      `json:"opts"`
+	Workspace TFCWorkspace           `json:"workspace"`
+	Carrier   propagation.MapCarrier `json:"Carrier"`
+
+	ctx context.Context
+}
+
+// GetId returns the JetStream message ID, used as a dedup key inside
+// JetStream's deduplication window. A duplicate webhook (or redelivery of
+// the parent MR event) cannot enqueue the same workspace+commit+action twice.
+//
+// The ID is a hex SHA-256 of the canonical fields rather than a delimited
+// string so it can't be accidentally collided by exotic project or workspace
+// names that contain the delimiter.
+func (m *WorkspaceTriggerMsg) GetId(ctx context.Context) string {
+	h := sha256.New()
+	enc := json.NewEncoder(h)
+	_ = enc.Encode([]any{
+		m.Opts.ProjectNameWithNamespace,
+		m.Opts.MergeRequestIID,
+		m.Opts.CommitSHA,
+		m.Opts.Action.String(),
+		m.Opts.VcsProvider,
+		m.Workspace.Name,
+		m.Workspace.Organization,
+	})
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (m *WorkspaceTriggerMsg) DecodeEventData(b []byte) error {
+	if err := json.Unmarshal(b, m); err != nil {
+		return err
+	}
+	m.ctx = otel.GetTextMapPropagator().Extract(context.Background(), m.Carrier)
+	return nil
+}
+
+func (m *WorkspaceTriggerMsg) EncodeEventData(ctx context.Context) []byte {
+	m.Carrier = make(map[string]string)
+	otel.GetTextMapPropagator().Inject(ctx, m.Carrier)
+	b, err := json.Marshal(m)
+	if err != nil {
+		log.Error().Err(err).Msg("could not encode WorkspaceTriggerMsg")
+	}
+	return b
+}
+
+func (m *WorkspaceTriggerMsg) Context() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
+// WorkspaceStream wraps a gongs.GenericStream so callers don't need to import
+// gongs directly to publish or subscribe.
+type WorkspaceStream struct {
+	stream *gongs.GenericStream[WorkspaceTriggerMsg, *WorkspaceTriggerMsg]
+}
+
+// NewWorkspaceStream provisions the JetStream that backs workspace fan-out
+// and returns a publisher/subscriber wrapper.
+func NewWorkspaceStream(js nats.JetStreamContext) (*WorkspaceStream, error) {
+	cfg := &nats.StreamConfig{
+		Name:        WorkspaceTriggerStreamName,
+		Description: "Fan-out queue: one message per workspace dispatched by an MR/PR trigger",
+		Subjects:    []string{fmt.Sprintf("%s.>", WorkspaceTriggerStreamName)},
+		Retention:   nats.WorkQueuePolicy,
+		MaxMsgs:     workspaceStreamMaxMsgs,
+		MaxAge:      workspaceStreamMaxAge,
+		Replicas:    1,
+	}
+
+	info, err := js.StreamInfo(cfg.Name)
+	switch {
+	case errors.Is(err, nats.ErrStreamNotFound):
+		if _, err := js.AddStream(cfg); err != nil {
+			return nil, fmt.Errorf("could not create %s stream: %w", cfg.Name, err)
+		}
+	case err != nil:
+		return nil, fmt.Errorf("could not read %s stream info: %w", cfg.Name, err)
+	case info != nil:
+		if _, err := js.UpdateStream(cfg); err != nil {
+			return nil, fmt.Errorf("could not update %s stream: %w", cfg.Name, err)
+		}
+	}
+
+	return &WorkspaceStream{
+		stream: gongs.NewGenericStream[WorkspaceTriggerMsg](js, workspaceTriggerSubject, WorkspaceTriggerStreamName),
+	}, nil
+}
+
+// Publish fans out a workspace trigger.
+func (s *WorkspaceStream) Publish(ctx context.Context, msg *WorkspaceTriggerMsg) error {
+	if s == nil || s.stream == nil {
+		return errors.New("workspace stream not configured")
+	}
+	_, err := s.stream.Publish(ctx, msg)
+	return err
+}
+
+// QueueSubscribe registers a worker on the shared queue. All replicas of the
+// hooks server share the same queue group, so each message is delivered to
+// exactly one worker.
+func (s *WorkspaceStream) QueueSubscribe(handler func(*WorkspaceTriggerMsg) error) (*nats.Subscription, error) {
+	return s.stream.QueueSubscribe(workspaceTriggerQueueName, handler)
+}

--- a/pkg/tfc_trigger/workspace_stream.go
+++ b/pkg/tfc_trigger/workspace_stream.go
@@ -22,7 +22,7 @@ import (
 // JetStream redelivering when the batch has many workspaces.
 const (
 	WorkspaceTriggerStreamName = "TFBUDDY_WORKSPACE_TRIGGERS"
-	workspaceTriggerSubject    = "TFBUDDY_WORKSPACE_TRIGGERS.dispatch"
+	workspaceTriggerSubject    = WorkspaceTriggerStreamName + ".dispatch"
 	workspaceTriggerQueueName  = "tfbuddy_workspace_trigger_worker"
 
 	// Sized to match HOOKS/RUN_EVENTS so a noisy day cannot push older

--- a/pkg/tfc_trigger/workspace_stream.go
+++ b/pkg/tfc_trigger/workspace_stream.go
@@ -16,28 +16,15 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 )
 
-// WorkspaceTriggerStreamName is the JetStream that carries one message per
-// workspace that needs a TFC run dispatched. Each MR/PR event fans out into
-// these messages so the upstream hook subscriber can ACK quickly and avoid
-// JetStream redelivering when the batch has many workspaces.
 const (
 	WorkspaceTriggerStreamName = "TFBUDDY_WORKSPACE_TRIGGERS"
 	workspaceTriggerSubject    = WorkspaceTriggerStreamName + ".dispatch"
 	workspaceTriggerQueueName  = "tfbuddy_workspace_trigger_worker"
 
-	// Sized to match HOOKS/RUN_EVENTS so a noisy day cannot push older
-	// streams off the broker. At ~1KB per msg, 10240 msgs is ~10MB peak.
 	workspaceStreamMaxMsgs = 10240
-
-	// A workspace trigger that hasn't been picked up within an hour is stale
-	// (the user has likely re-triggered or the MR is gone). Dropping it is
-	// safer than dispatching a run against an old commit.
-	workspaceStreamMaxAge = time.Hour
+	workspaceStreamMaxAge  = time.Hour
 )
 
-// WorkspaceTriggerMsg is the unit of work consumed by WorkspaceTriggerWorker.
-// It contains everything required to drive a single workspace's TFC run from
-// scratch, with no shared state across workspaces.
 type WorkspaceTriggerMsg struct {
 	Opts      TFCTriggerOptions      `json:"opts"`
 	Workspace TFCWorkspace           `json:"workspace"`
@@ -46,14 +33,15 @@ type WorkspaceTriggerMsg struct {
 	ctx context.Context
 }
 
-// GetId returns the JetStream message ID, used as a dedup key inside
-// JetStream's deduplication window. A duplicate webhook (or redelivery of
-// the parent MR event) cannot enqueue the same workspace+commit+action twice.
-//
-// The ID is a hex SHA-256 of the canonical fields rather than a delimited
-// string so it can't be accidentally collided by exotic project or workspace
-// names that contain the delimiter.
+// GetId is the JetStream dedup key. When DeliveryID is present (the normal
+// path for GitHub X-GitHub-Delivery / GitLab Idempotency-Key), we compose the
+// key directly from the opaque per-delivery identifier plus workspace identity.
+// The sha256 fallback handles only legacy messages missing the delivery header.
 func (m *WorkspaceTriggerMsg) GetId(ctx context.Context) string {
+	if m.Opts.DeliveryID != "" {
+		return m.Opts.DeliveryID + "/" + m.Workspace.Name + "/" + m.Workspace.Organization
+	}
+
 	h := sha256.New()
 	enc := json.NewEncoder(h)
 	_ = enc.Encode([]any{
@@ -93,15 +81,12 @@ func (m *WorkspaceTriggerMsg) Context() context.Context {
 	return context.Background()
 }
 
-// WorkspaceStream wraps a gongs.GenericStream so callers don't need to import
-// gongs directly to publish or subscribe.
 type WorkspaceStream struct {
+	js     nats.JetStreamContext
 	stream *gongs.GenericStream[WorkspaceTriggerMsg, *WorkspaceTriggerMsg]
 }
 
-// NewWorkspaceStream provisions the JetStream that backs workspace fan-out
-// and returns a publisher/subscriber wrapper.
-func NewWorkspaceStream(js nats.JetStreamContext) (*WorkspaceStream, error) {
+func NewWorkspaceStream(js nats.JetStreamContext, workspaceStreamReplicas int) (*WorkspaceStream, error) {
 	cfg := &nats.StreamConfig{
 		Name:        WorkspaceTriggerStreamName,
 		Description: "Fan-out queue: one message per workspace dispatched by an MR/PR trigger",
@@ -109,7 +94,7 @@ func NewWorkspaceStream(js nats.JetStreamContext) (*WorkspaceStream, error) {
 		Retention:   nats.WorkQueuePolicy,
 		MaxMsgs:     workspaceStreamMaxMsgs,
 		MaxAge:      workspaceStreamMaxAge,
-		Replicas:    1,
+		Replicas:    workspaceStreamReplicas,
 	}
 
 	info, err := js.StreamInfo(cfg.Name)
@@ -127,11 +112,11 @@ func NewWorkspaceStream(js nats.JetStreamContext) (*WorkspaceStream, error) {
 	}
 
 	return &WorkspaceStream{
+		js:     js,
 		stream: gongs.NewGenericStream[WorkspaceTriggerMsg](js, workspaceTriggerSubject, WorkspaceTriggerStreamName),
 	}, nil
 }
 
-// Publish fans out a workspace trigger.
 func (s *WorkspaceStream) Publish(ctx context.Context, msg *WorkspaceTriggerMsg) error {
 	if s == nil || s.stream == nil {
 		return errors.New("workspace stream not configured")
@@ -140,9 +125,37 @@ func (s *WorkspaceStream) Publish(ctx context.Context, msg *WorkspaceTriggerMsg)
 	return err
 }
 
-// QueueSubscribe registers a worker on the shared queue. All replicas of the
-// hooks server share the same queue group, so each message is delivered to
-// exactly one worker.
+// QueueSubscribe binds workers to a shared queue so each message is delivered
+// to exactly one replica.
 func (s *WorkspaceStream) QueueSubscribe(handler func(*WorkspaceTriggerMsg) error) (*nats.Subscription, error) {
 	return s.stream.QueueSubscribe(workspaceTriggerQueueName, handler)
+}
+
+// HealthCheck reports unhealthy when the stream is missing from JetStream,
+// or when it has no consumers (published messages would otherwise pile up
+// undelivered).
+func (s *WorkspaceStream) HealthCheck() error {
+	if s == nil || s.js == nil {
+		return errors.New("workspace stream not configured")
+	}
+	info, err := s.js.StreamInfo(WorkspaceTriggerStreamName)
+	if err != nil {
+		if errors.Is(err, nats.ErrStreamNotFound) {
+			log.Warn().Str("stream", WorkspaceTriggerStreamName).
+				Msg("Healthcheck status: workspace trigger stream not found in JetStream")
+			return fmt.Errorf("%s stream not found in JetStream", WorkspaceTriggerStreamName)
+		}
+		return fmt.Errorf("could not read %s stream info: %w", WorkspaceTriggerStreamName, err)
+	}
+	if info.State.Consumers < 1 {
+		ev := log.Warn().Str("stream", info.Config.Name).
+			Int("consumers", info.State.Consumers).
+			Uint64("msgs", info.State.Msgs)
+		if info.Cluster != nil {
+			ev = ev.Str("cluster_leader", info.Cluster.Leader)
+		}
+		ev.Msg("Healthcheck status.")
+		return fmt.Errorf("%s stream has no consumers", info.Config.Name)
+	}
+	return nil
 }

--- a/pkg/tfc_trigger/workspace_stream_test.go
+++ b/pkg/tfc_trigger/workspace_stream_test.go
@@ -1,0 +1,361 @@
+package tfc_trigger_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zapier/tfbuddy/pkg/mocks"
+	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
+)
+
+// fakeWorkspacePublisher is a thread-safe in-memory stand-in for the
+// production NATS-backed WorkspaceStream. Tests use it to assert exactly which
+// workspaces would have been enqueued without spinning up JetStream.
+type fakeWorkspacePublisher struct {
+	mu       sync.Mutex
+	msgs     []*tfc_trigger.WorkspaceTriggerMsg
+	failOnce *string
+}
+
+func (f *fakeWorkspacePublisher) Publish(ctx context.Context, msg *tfc_trigger.WorkspaceTriggerMsg) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failOnce != nil && *f.failOnce == msg.Workspace.Name {
+		f.failOnce = nil
+		return fmt.Errorf("simulated publish failure")
+	}
+	f.msgs = append(f.msgs, msg)
+	return nil
+}
+
+func (f *fakeWorkspacePublisher) names() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.msgs))
+	for _, m := range f.msgs {
+		out = append(out, m.Workspace.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildFanoutWorkspaces builds an N-workspace ProjectConfig where each
+// workspace points at a unique service directory.
+func buildFanoutWorkspaces(n int) *tfc_trigger.ProjectConfig {
+	wss := make([]*tfc_trigger.TFCWorkspace, 0, n)
+	for i := 0; i < n; i++ {
+		wss = append(wss, &tfc_trigger.TFCWorkspace{
+			Name:         fmt.Sprintf("service-tfbuddy-%02d", i),
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+			Dir:          fmt.Sprintf("services/svc%02d/", i),
+		})
+	}
+	return &tfc_trigger.ProjectConfig{Workspaces: wss}
+}
+
+// TestTriggerTFCEvents_FansOutPerWorkspace verifies the production path
+// publishes one message per touched workspace and does no inline TFC work
+// (no clone, no per-workspace API calls). This is the durability boundary
+// that lets the JetStream subscriber ACK quickly regardless of batch size.
+func TestTriggerTFCEvents_FansOutPerWorkspace(t *testing.T) {
+	const numWorkspaces = 20
+	cfg := buildFanoutWorkspaces(numWorkspaces)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	modified := make([]string, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
+	}
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
+
+	// No inline run/discussion/clone work — those would all be expectation
+	// failures because the mocks do not allow them. Setting up the mocks this
+	// way doubles as a regression guard: if TriggerTFCEvents ever falls back
+	// to the inline path while a publisher is set, the unmocked call panics.
+	testSuite.InitTestSuite()
+
+	pub := &fakeWorkspacePublisher{}
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger.SetWorkspaceStream(pub)
+
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	status, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.Errored) != 0 {
+		t.Fatalf("expected no errored workspaces, got: %v", status.Errored)
+	}
+	if len(status.Executed) != numWorkspaces {
+		t.Fatalf("expected %d enqueued workspaces, got %d (%v)", numWorkspaces, len(status.Executed), status.Executed)
+	}
+	got := pub.names()
+	if len(got) != numWorkspaces {
+		t.Fatalf("expected %d published messages, got %d", numWorkspaces, len(got))
+	}
+	for i, name := range got {
+		want := fmt.Sprintf("service-tfbuddy-%02d", i)
+		if name != want {
+			t.Fatalf("publish[%d] = %s, want %s", i, name, want)
+		}
+	}
+}
+
+// TestTriggerTFCEvents_PublishFailureReportsErrored verifies that when the
+// stream rejects a publish (NATS down, etc.) the failed workspace surfaces in
+// Errored so the comment-trigger flow can still tell the user.
+func TestTriggerTFCEvents_PublishFailureReportsErrored(t *testing.T) {
+	cfg := buildFanoutWorkspaces(3)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return([]string{
+		"services/svc00/main.tf", "services/svc01/main.tf", "services/svc02/main.tf",
+	}, nil).AnyTimes()
+	testSuite.InitTestSuite()
+
+	failName := "service-tfbuddy-01"
+	pub := &fakeWorkspacePublisher{failOnce: &failName}
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.PlanAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger.SetWorkspaceStream(pub)
+
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	status, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(status.Errored) != 1 || status.Errored[0].Name != failName {
+		t.Fatalf("expected exactly one errored workspace (%s), got: %+v", failName, status.Errored)
+	}
+	if len(status.Executed) != 2 {
+		t.Fatalf("expected the other two workspaces to enqueue, got executed=%v", status.Executed)
+	}
+}
+
+// TestTriggerTFCEvents_NoChangesWithStreamSet verifies the fan-out path still
+// short-circuits when no workspaces are touched. This must not enqueue any
+// messages — otherwise we'd get useless TFC runs against unchanged paths.
+func TestTriggerTFCEvents_NoChangesWithStreamSet(t *testing.T) {
+	cfg := buildFanoutWorkspaces(2)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return([]string{"README.md"}, nil).AnyTimes()
+	testSuite.InitTestSuite()
+
+	pub := &fakeWorkspacePublisher{}
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.PlanAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger.SetWorkspaceStream(pub)
+
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	status, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != nil {
+		t.Fatalf("expected nil status when no workspaces touched, got: %+v", status)
+	}
+	if got := len(pub.msgs); got != 0 {
+		t.Fatalf("expected zero published messages, got %d", got)
+	}
+}
+
+// TestWorkspaceTriggerMsg_GetIdIsStable guards the JetStream dedup key: a
+// duplicate webhook (or redelivery) must produce the same ID for the same
+// (project, MR, commit, action, workspace) tuple, otherwise NATS will accept
+// the duplicate and we'll enqueue twice.
+func TestWorkspaceTriggerMsg_GetIdIsStable(t *testing.T) {
+	mk := func() *tfc_trigger.WorkspaceTriggerMsg {
+		return &tfc_trigger.WorkspaceTriggerMsg{
+			Opts: tfc_trigger.TFCTriggerOptions{
+				Action:                   tfc_trigger.PlanAction,
+				ProjectNameWithNamespace: "zapier/tfbuddy",
+				MergeRequestIID:          42,
+				CommitSHA:                "deadbeef",
+				VcsProvider:              "gitlab",
+			},
+			Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+		}
+	}
+	ctx := context.Background()
+	a, b := mk().GetId(ctx), mk().GetId(ctx)
+	if a != b {
+		t.Fatalf("GetId not deterministic: %s vs %s", a, b)
+	}
+
+	// Different workspace must produce a different ID, otherwise we'd dedupe
+	// across workspaces and silently drop fan-out messages.
+	other := mk()
+	other.Workspace.Name = "service-tfbuddy-staging"
+	if other.GetId(ctx) == a {
+		t.Fatal("GetId collided across workspaces")
+	}
+
+	// Different action (plan vs apply) must dedup independently — otherwise
+	// commenting `tfc apply` after `tfc plan` on the same commit would be
+	// silently dropped within the dedup window.
+	otherAction := mk()
+	otherAction.Opts.Action = tfc_trigger.ApplyAction
+	if otherAction.GetId(ctx) == a {
+		t.Fatal("GetId collided across actions")
+	}
+
+	// Different commit must dedup independently — otherwise re-pushing a
+	// branch with new code wouldn't re-trigger plans during the dedup window.
+	otherCommit := mk()
+	otherCommit.Opts.CommitSHA = "feedface"
+	if otherCommit.GetId(ctx) == a {
+		t.Fatal("GetId collided across commits")
+	}
+
+	// Pipe characters in workspace names mustn't collide with other tuples
+	// (regression guard for the previous delimiter-based encoding).
+	weird := mk()
+	weird.Workspace.Name = "service|name|with|pipes"
+	weird2 := mk()
+	weird2.Opts.ProjectNameWithNamespace = "service|name|with|pipes"
+	if weird.GetId(ctx) == weird2.GetId(ctx) {
+		t.Fatal("GetId collides when the workspace name contains the old delimiter")
+	}
+}
+
+// TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips ensures the over-the-wire
+// representation preserves enough state to fully reconstruct the trigger in
+// the workspace worker (no shared state between MR worker and ws worker).
+func TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips(t *testing.T) {
+	original := &tfc_trigger.WorkspaceTriggerMsg{
+		Opts: tfc_trigger.TFCTriggerOptions{
+			Action:                   tfc_trigger.ApplyAction,
+			Branch:                   "feature-x",
+			CommitSHA:                "deadbeef",
+			ProjectNameWithNamespace: "zapier/tfbuddy",
+			MergeRequestIID:          42,
+			TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+			VcsProvider:              "gitlab",
+			TFVersion:                "1.5.0",
+			AllowEmptyRun:            true,
+		},
+		Workspace: tfc_trigger.TFCWorkspace{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+			Dir:          "production/",
+			TriggerDirs:  []string{"production/**"},
+			AutoMerge:    true,
+		},
+	}
+	data := original.EncodeEventData(context.Background())
+	if len(data) == 0 {
+		t.Fatal("encoded payload is empty")
+	}
+
+	decoded := &tfc_trigger.WorkspaceTriggerMsg{}
+	if err := decoded.DecodeEventData(data); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.Opts.Action != original.Opts.Action ||
+		decoded.Opts.MergeRequestIID != original.Opts.MergeRequestIID ||
+		decoded.Opts.CommitSHA != original.Opts.CommitSHA ||
+		decoded.Opts.VcsProvider != original.Opts.VcsProvider ||
+		decoded.Workspace.Name != original.Workspace.Name ||
+		decoded.Workspace.Mode != original.Workspace.Mode ||
+		decoded.Workspace.AutoMerge != original.Workspace.AutoMerge {
+		t.Fatalf("roundtrip lost state.\n original=%+v\n decoded=%+v", original, decoded)
+	}
+}
+
+// TestTriggerTFCEvents_FanoutIsConcurrencySafe runs many enqueue rounds
+// concurrently; the workspace-local cfg/discussion/note fix means each
+// trigger keeps its own state and the publisher never sees crossed wires.
+// Run with -race to catch regressions.
+func TestTriggerTFCEvents_FanoutIsConcurrencySafe(t *testing.T) {
+	const numWorkspaces = 8
+	cfg := buildFanoutWorkspaces(numWorkspaces)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	modified := make([]string, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
+	}
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.PlanAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+
+	pub := &fakeWorkspacePublisher{}
+	trigger.SetWorkspaceStream(pub)
+
+	const rounds = 16
+	var wg sync.WaitGroup
+	var failures int32
+	for i := 0; i < rounds; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+			if _, err := trigger.TriggerTFCEvents(ctx); err != nil {
+				atomic.AddInt32(&failures, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&failures); got != 0 {
+		t.Fatalf("%d concurrent TriggerTFCEvents calls failed", got)
+	}
+	if got := len(pub.msgs); got != rounds*numWorkspaces {
+		t.Fatalf("expected %d publish calls, got %d", rounds*numWorkspaces, got)
+	}
+}

--- a/pkg/tfc_trigger/workspace_stream_test.go
+++ b/pkg/tfc_trigger/workspace_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,13 +12,12 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/mock/gomock"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/mocks"
 	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
 )
 
-// fakeWorkspacePublisher is a thread-safe in-memory stand-in for the
-// production NATS-backed WorkspaceStream. Tests use it to assert exactly which
-// workspaces would have been enqueued without spinning up JetStream.
+// fakeWorkspacePublisher is an in-memory stand-in for WorkspaceStream.
 type fakeWorkspacePublisher struct {
 	mu       sync.Mutex
 	msgs     []*tfc_trigger.WorkspaceTriggerMsg
@@ -46,8 +46,6 @@ func (f *fakeWorkspacePublisher) names() []string {
 	return out
 }
 
-// buildFanoutWorkspaces builds an N-workspace ProjectConfig where each
-// workspace points at a unique service directory.
 func buildFanoutWorkspaces(n int) *tfc_trigger.ProjectConfig {
 	wss := make([]*tfc_trigger.TFCWorkspace, 0, n)
 	for i := 0; i < n; i++ {
@@ -61,10 +59,8 @@ func buildFanoutWorkspaces(n int) *tfc_trigger.ProjectConfig {
 	return &tfc_trigger.ProjectConfig{Workspaces: wss}
 }
 
-// TestTriggerTFCEvents_FansOutPerWorkspace verifies the production path
-// publishes one message per touched workspace and does no inline TFC work
-// (no clone, no per-workspace API calls). This is the durability boundary
-// that lets the JetStream subscriber ACK quickly regardless of batch size.
+// TestTriggerTFCEvents_FansOutPerWorkspace asserts one publish per touched
+// workspace and no inline clone/API work. Unmocked inline calls would panic.
 func TestTriggerTFCEvents_FansOutPerWorkspace(t *testing.T) {
 	const numWorkspaces = 20
 	cfg := buildFanoutWorkspaces(numWorkspaces)
@@ -79,10 +75,6 @@ func TestTriggerTFCEvents_FansOutPerWorkspace(t *testing.T) {
 	}
 	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
 
-	// No inline run/discussion/clone work — those would all be expectation
-	// failures because the mocks do not allow them. Setting up the mocks this
-	// way doubles as a regression guard: if TriggerTFCEvents ever falls back
-	// to the inline path while a publisher is set, the unmocked call panics.
 	testSuite.InitTestSuite()
 
 	pub := &fakeWorkspacePublisher{}
@@ -94,7 +86,7 @@ func TestTriggerTFCEvents_FansOutPerWorkspace(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.Config{}, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	trigger.SetWorkspaceStream(pub)
 
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
@@ -120,9 +112,8 @@ func TestTriggerTFCEvents_FansOutPerWorkspace(t *testing.T) {
 	}
 }
 
-// TestTriggerTFCEvents_PublishFailureReportsErrored verifies that when the
-// stream rejects a publish (NATS down, etc.) the failed workspace surfaces in
-// Errored so the comment-trigger flow can still tell the user.
+// TestTriggerTFCEvents_PublishFailureReportsErrored asserts that a publish
+// failure surfaces in Errored so comment-trigger callers can surface it.
 func TestTriggerTFCEvents_PublishFailureReportsErrored(t *testing.T) {
 	cfg := buildFanoutWorkspaces(3)
 
@@ -146,7 +137,7 @@ func TestTriggerTFCEvents_PublishFailureReportsErrored(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.Config{}, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	trigger.SetWorkspaceStream(pub)
 
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
@@ -163,9 +154,8 @@ func TestTriggerTFCEvents_PublishFailureReportsErrored(t *testing.T) {
 	}
 }
 
-// TestTriggerTFCEvents_NoChangesWithStreamSet verifies the fan-out path still
-// short-circuits when no workspaces are touched. This must not enqueue any
-// messages — otherwise we'd get useless TFC runs against unchanged paths.
+// TestTriggerTFCEvents_NoChangesWithStreamSet asserts the fan-out path
+// short-circuits when no workspaces are touched.
 func TestTriggerTFCEvents_NoChangesWithStreamSet(t *testing.T) {
 	cfg := buildFanoutWorkspaces(2)
 
@@ -185,7 +175,7 @@ func TestTriggerTFCEvents_NoChangesWithStreamSet(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.Config{}, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	trigger.SetWorkspaceStream(pub)
 
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
@@ -193,18 +183,19 @@ func TestTriggerTFCEvents_NoChangesWithStreamSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != nil {
-		t.Fatalf("expected nil status when no workspaces touched, got: %+v", status)
+	if status == nil {
+		t.Fatal("expected non-nil empty status when no workspaces touched, got nil")
+	}
+	if len(status.Errored) != 0 || len(status.Executed) != 0 {
+		t.Fatalf("expected empty status when no workspaces touched, got: %+v", status)
 	}
 	if got := len(pub.msgs); got != 0 {
 		t.Fatalf("expected zero published messages, got %d", got)
 	}
 }
 
-// TestWorkspaceTriggerMsg_GetIdIsStable guards the JetStream dedup key: a
-// duplicate webhook (or redelivery) must produce the same ID for the same
-// (project, MR, commit, action, workspace) tuple, otherwise NATS will accept
-// the duplicate and we'll enqueue twice.
+// TestWorkspaceTriggerMsg_GetIdIsStable asserts the dedup key is deterministic
+// for the same tuple and distinct across workspace / action / commit changes.
 func TestWorkspaceTriggerMsg_GetIdIsStable(t *testing.T) {
 	mk := func() *tfc_trigger.WorkspaceTriggerMsg {
 		return &tfc_trigger.WorkspaceTriggerMsg{
@@ -224,33 +215,25 @@ func TestWorkspaceTriggerMsg_GetIdIsStable(t *testing.T) {
 		t.Fatalf("GetId not deterministic: %s vs %s", a, b)
 	}
 
-	// Different workspace must produce a different ID, otherwise we'd dedupe
-	// across workspaces and silently drop fan-out messages.
 	other := mk()
 	other.Workspace.Name = "service-tfbuddy-staging"
 	if other.GetId(ctx) == a {
 		t.Fatal("GetId collided across workspaces")
 	}
 
-	// Different action (plan vs apply) must dedup independently — otherwise
-	// commenting `tfc apply` after `tfc plan` on the same commit would be
-	// silently dropped within the dedup window.
 	otherAction := mk()
 	otherAction.Opts.Action = tfc_trigger.ApplyAction
 	if otherAction.GetId(ctx) == a {
 		t.Fatal("GetId collided across actions")
 	}
 
-	// Different commit must dedup independently — otherwise re-pushing a
-	// branch with new code wouldn't re-trigger plans during the dedup window.
 	otherCommit := mk()
 	otherCommit.Opts.CommitSHA = "feedface"
 	if otherCommit.GetId(ctx) == a {
 		t.Fatal("GetId collided across commits")
 	}
 
-	// Pipe characters in workspace names mustn't collide with other tuples
-	// (regression guard for the previous delimiter-based encoding).
+	// Regression guard for the previous pipe-delimited encoding.
 	weird := mk()
 	weird.Workspace.Name = "service|name|with|pipes"
 	weird2 := mk()
@@ -260,9 +243,105 @@ func TestWorkspaceTriggerMsg_GetIdIsStable(t *testing.T) {
 	}
 }
 
-// TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips ensures the over-the-wire
-// representation preserves enough state to fully reconstruct the trigger in
-// the workspace worker (no shared state between MR worker and ws worker).
+// TestWorkspaceTriggerMsg_GetIdAnchorsOnDeliveryID asserts the dedup key is
+// anchored to the webhook delivery so retriggers aren't silently dropped.
+func TestWorkspaceTriggerMsg_GetIdAnchorsOnDeliveryID(t *testing.T) {
+	ctx := context.Background()
+	mk := func(deliveryID string) *tfc_trigger.WorkspaceTriggerMsg {
+		return &tfc_trigger.WorkspaceTriggerMsg{
+			Opts: tfc_trigger.TFCTriggerOptions{
+				Action:                   tfc_trigger.PlanAction,
+				ProjectNameWithNamespace: "zapier/tfbuddy",
+				MergeRequestIID:          42,
+				CommitSHA:                "deadbeef",
+				VcsProvider:              "gitlab",
+				DeliveryID:               deliveryID,
+			},
+			Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+		}
+	}
+
+	first := mk("delivery-aaa").GetId(ctx)
+	second := mk("delivery-bbb").GetId(ctx)
+	if first == second {
+		t.Fatalf("retrigger from a different webhook delivery must produce a fresh dedup key, got %q", first)
+	}
+
+	dup := mk("delivery-aaa").GetId(ctx)
+	if dup != first {
+		t.Fatalf("same delivery+workspace must produce the same dedup key (%q vs %q)", first, dup)
+	}
+
+	siblingWS := mk("delivery-aaa")
+	siblingWS.Workspace.Name = "service-tfbuddy-staging"
+	if siblingWS.GetId(ctx) == first {
+		t.Fatal("same delivery across workspaces must not collide")
+	}
+
+	// Delivery ID stays embedded for greppability during incident triage.
+	if !strings.Contains(first, "delivery-aaa") {
+		t.Fatalf("expected delivery ID embedded in dedup key, got %q", first)
+	}
+
+	// Workspace name and org are embedded directly (no hash).
+	if !strings.Contains(first, "service-tfbuddy") {
+		t.Fatalf("expected workspace name embedded in dedup key, got %q", first)
+	}
+	if !strings.Contains(first, "zapier-test") {
+		t.Fatalf("expected org embedded in dedup key, got %q", first)
+	}
+
+	// Verify the exact format: DeliveryID/Workspace.Name/Workspace.Organization
+	expected := "delivery-aaa/service-tfbuddy/zapier-test"
+	if first != expected {
+		t.Fatalf("expected key %q, got %q", expected, first)
+	}
+}
+
+// TestWorkspaceTriggerMsg_GetIdNoDelimiterCollision regresses encoding bugs
+// where ambiguous splits could produce the same key for different tuples.
+func TestWorkspaceTriggerMsg_GetIdNoDelimiterCollision(t *testing.T) {
+	ctx := context.Background()
+	mk := func(deliveryID, org, name string) *tfc_trigger.WorkspaceTriggerMsg {
+		return &tfc_trigger.WorkspaceTriggerMsg{
+			Opts: tfc_trigger.TFCTriggerOptions{
+				Action:                   tfc_trigger.PlanAction,
+				ProjectNameWithNamespace: "zapier/tfbuddy",
+				MergeRequestIID:          42,
+				CommitSHA:                "deadbeef",
+				VcsProvider:              "gitlab",
+				DeliveryID:               deliveryID,
+			},
+			Workspace: tfc_trigger.TFCWorkspace{Organization: org, Name: name},
+		}
+	}
+
+	cases := []struct {
+		name string
+		a, b *tfc_trigger.WorkspaceTriggerMsg
+	}{
+		{
+			name: "dash in delivery vs start of workspace name",
+			a:    mk("abc-def", "ws1", "prod"),
+			b:    mk("abc", "def-ws1", "prod"),
+		},
+		{
+			name: "dash in org vs start of workspace name",
+			a:    mk("abc", "ws1", "prod-extra"),
+			b:    mk("abc", "ws1-prod", "extra"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.a.GetId(ctx) == tc.b.GetId(ctx) {
+				t.Fatalf("GetId collided across distinct tuples:\n  %+v\n  %+v", tc.a, tc.b)
+			}
+		})
+	}
+}
+
+// TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips asserts the over-the-wire
+// payload preserves the state the worker needs.
 func TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips(t *testing.T) {
 	original := &tfc_trigger.WorkspaceTriggerMsg{
 		Opts: tfc_trigger.TFCTriggerOptions{
@@ -305,10 +384,8 @@ func TestWorkspaceTriggerMsg_EncodeDecodeRoundtrips(t *testing.T) {
 	}
 }
 
-// TestTriggerTFCEvents_FanoutIsConcurrencySafe runs many enqueue rounds
-// concurrently; the workspace-local cfg/discussion/note fix means each
-// trigger keeps its own state and the publisher never sees crossed wires.
-// Run with -race to catch regressions.
+// TestTriggerTFCEvents_FanoutIsConcurrencySafe drives concurrent enqueues to
+// catch shared-state regressions (run with -race).
 func TestTriggerTFCEvents_FanoutIsConcurrencySafe(t *testing.T) {
 	const numWorkspaces = 8
 	cfg := buildFanoutWorkspaces(numWorkspaces)
@@ -332,7 +409,7 @@ func TestTriggerTFCEvents_FanoutIsConcurrencySafe(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.Config{}, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 
 	pub := &fakeWorkspacePublisher{}
 	trigger.SetWorkspaceStream(pub)

--- a/pkg/tfc_trigger/workspace_worker.go
+++ b/pkg/tfc_trigger/workspace_worker.go
@@ -1,0 +1,158 @@
+package tfc_trigger
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/zapier/tfbuddy/pkg/runstream"
+	"github.com/zapier/tfbuddy/pkg/tfc_api"
+	"github.com/zapier/tfbuddy/pkg/vcs"
+)
+
+// WorkspaceTriggerWorker drains the WorkspaceTriggerStream and dispatches one
+// TFC run per message. Each delivery is processed independently, so the
+// JetStream AckWait window applies per workspace rather than per MR/PR — this
+// is the durability boundary the fan-out provides.
+type WorkspaceTriggerWorker struct {
+	gl        vcs.GitClient
+	tfc       tfc_api.ApiClient
+	runstream runstream.StreamClient
+}
+
+// NewWorkspaceTriggerWorker subscribes to the workspace stream and starts
+// processing messages. The subscription is queue-bound so multiple replicas
+// share the load.
+func NewWorkspaceTriggerWorker(stream *WorkspaceStream, gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) (*WorkspaceTriggerWorker, error) {
+	w := NewWorkspaceTriggerWorkerWithoutSubscription(gl, tfc, rs)
+	if _, err := stream.QueueSubscribe(w.HandleMsg); err != nil {
+		return nil, fmt.Errorf("could not subscribe to workspace trigger stream: %w", err)
+	}
+	return w, nil
+}
+
+// NewWorkspaceTriggerWorkerWithoutSubscription constructs a worker without
+// subscribing to a stream. Used by tests that drive HandleMsg directly.
+func NewWorkspaceTriggerWorkerWithoutSubscription(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) *WorkspaceTriggerWorker {
+	return &WorkspaceTriggerWorker{gl: gl, tfc: tfc, runstream: rs}
+}
+
+// HandleMsg processes a single workspace trigger delivery. JetStream calls
+// this via the queue subscription; tests call it directly.
+func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error) {
+	ctx, span := otel.Tracer("TFC").Start(msg.Context(), "WorkspaceTriggerWorker.handle",
+		trace.WithAttributes(
+			attribute.String("workspace", msg.Workspace.Name),
+			attribute.String("project", msg.Opts.ProjectNameWithNamespace),
+			attribute.Int("mr", msg.Opts.MergeRequestIID),
+			attribute.String("action", msg.Opts.Action.String()),
+		))
+	defer span.End()
+
+	defer func() {
+		// Never let a panic propagate into JetStream — that would tear down
+		// the subscription. Treat it like any other failure and surface it on
+		// the MR so the user knows their request didn't go through.
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).
+				Str("workspace", msg.Workspace.Name).
+				Msg("recovered from panic in workspace worker")
+			w.postWorkspaceError(ctx, &msg.Opts, msg.Workspace.Name, fmt.Errorf("internal error: %v", r))
+			rerr = nil
+		}
+	}()
+
+	if err := w.runWorkspace(ctx, msg); err != nil {
+		log.Error().Err(err).
+			Str("workspace", msg.Workspace.Name).
+			Str("project", msg.Opts.ProjectNameWithNamespace).
+			Int("mr", msg.Opts.MergeRequestIID).
+			Msg("workspace trigger failed")
+		w.postWorkspaceError(ctx, &msg.Opts, msg.Workspace.Name, err)
+		// Swallow the error and ACK: the user has been notified on the MR.
+		// Retrying would create duplicate discussions/runs, which is exactly
+		// the duplicate-state class of bug this fan-out is meant to prevent.
+		return nil
+	}
+	return nil
+}
+
+func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, msg *WorkspaceTriggerMsg) error {
+	ctx, span := otel.Tracer("TFC").Start(ctx, "WorkspaceTriggerWorker.run")
+	defer span.End()
+
+	cfg, err := NewTFCTriggerConfig(&msg.Opts)
+	if err != nil {
+		return fmt.Errorf("invalid trigger config: %w", err)
+	}
+	trigger := &TFCTrigger{
+		gl:        w.gl,
+		tfc:       w.tfc,
+		runstream: w.runstream,
+		cfg:       cfg,
+	}
+
+	mr, err := trigger.gl.GetMergeRequest(ctx, trigger.GetMergeRequestIID(), trigger.GetProjectNameWithNamespace())
+	if err != nil {
+		return fmt.Errorf("could not read MergeRequest data from VCS API: %w", err)
+	}
+
+	repo, err := trigger.cloneGitRepo(ctx, mr)
+	if err != nil {
+		return fmt.Errorf("could not clone repo: %w", err)
+	}
+	defer os.RemoveAll(repo.GetLocalDirectory())
+
+	// Re-check that this workspace's paths haven't moved on the target branch
+	// since the MR diverged. The MR-event worker can't do this cheaply (no
+	// clone), so we do it here per workspace.
+	if blocked, reason, err := trigger.workspaceBlockedByTargetBranch(ctx, mr, repo, &msg.Workspace); err != nil {
+		log.Warn().Err(err).Str("ws", msg.Workspace.Name).Msg("could not evaluate target-branch modifications")
+	} else if blocked {
+		return fmt.Errorf("%s", reason)
+	}
+
+	return trigger.triggerRunForWorkspace(ctx, &msg.Workspace, mr, repo.GetLocalDirectory())
+}
+
+// postWorkspaceError surfaces a workspace failure back to the MR/PR. The
+// per-workspace discussion is only created inside triggerRunForWorkspace, so
+// most failures happen before that and need a top-level comment instead.
+func (w *WorkspaceTriggerWorker) postWorkspaceError(ctx context.Context, opts *TFCTriggerOptions, ws string, err error) {
+	if w.gl == nil {
+		return
+	}
+	body := fmt.Sprintf(":no_entry: %s could not be run because: %s", ws, err.Error())
+	if cerr := w.gl.CreateMergeRequestComment(ctx, opts.MergeRequestIID, opts.ProjectNameWithNamespace, body); cerr != nil {
+		log.Error().Err(cerr).Str("workspace", ws).Msg("could not post workspace error to MR")
+	}
+}
+
+// workspaceBlockedByTargetBranch is a workspace-scoped equivalent of
+// getModifiedWorkspacesOnTargetBranch, kept on TFCTrigger so the per-workspace
+// worker can use it without iterating the whole project config.
+func (t *TFCTrigger) workspaceBlockedByTargetBranch(ctx context.Context, mr vcs.MR, repo vcs.GitRepo, ws *TFCWorkspace) (bool, string, error) {
+	ctx, span := otel.Tracer("TFC").Start(ctx, "workspaceBlockedByTargetBranch")
+	defer span.End()
+
+	if err := repo.FetchUpstreamBranch(mr.GetTargetBranch()); err != nil {
+		return false, "", fmt.Errorf("could not fetch target branch %s: %w", mr.GetTargetBranch(), err)
+	}
+	commonSHA, err := repo.GetMergeBase(mr.GetSourceBranch(), mr.GetTargetBranch())
+	if err != nil {
+		return false, "", fmt.Errorf("could not find merge base: %w", err)
+	}
+	targetModifiedFiles, err := repo.GetModifiedFileNamesBetweenCommits(commonSHA, mr.GetTargetBranch())
+	if err != nil {
+		return false, "", fmt.Errorf("could not list modified files between %s..%s: %w", commonSHA, mr.GetTargetBranch(), err)
+	}
+	if len(targetModifiedFiles) == 0 || !hasChangesForWorkspace(ws, targetModifiedFiles) {
+		return false, "", nil
+	}
+	return true, fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", ws.Dir, ws.TriggerDirs), nil
+}

--- a/pkg/tfc_trigger/workspace_worker.go
+++ b/pkg/tfc_trigger/workspace_worker.go
@@ -10,31 +10,25 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/vcs"
 )
 
-// WorkspaceTriggerWorker drains the WorkspaceTriggerStream and dispatches one
-// TFC run per message. Each delivery is processed independently, so the
-// JetStream AckWait window applies per workspace rather than per MR/PR — this
-// is the durability boundary the fan-out provides.
-//
-// The single workspace stream is shared across VCS providers, so the worker
-// keeps a per-provider client map keyed by TFCTriggerOptions.VcsProvider and
-// routes each message to the matching client. Without this, a GitHub-origin
-// trigger would be handled by the GitLab API client and fail consistently.
+// WorkspaceTriggerWorker drains the WorkspaceTriggerStream. Each delivery gets
+// its own AckWait window, which is the durability boundary the fan-out provides.
+// The stream is shared across VCS providers, so the worker routes each message
+// to the matching client by Opts.VcsProvider.
 type WorkspaceTriggerWorker struct {
+	appCfg    config.Config
 	clients   map[string]vcs.GitClient
 	tfc       tfc_api.ApiClient
 	runstream runstream.StreamClient
 }
 
-// NewWorkspaceTriggerWorker subscribes to the workspace stream and starts
-// processing messages. The subscription is queue-bound so multiple replicas
-// share the load.
-func NewWorkspaceTriggerWorker(stream *WorkspaceStream, clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) (*WorkspaceTriggerWorker, error) {
-	w := NewWorkspaceTriggerWorkerWithoutSubscription(clients, tfc, rs)
+func NewWorkspaceTriggerWorker(stream *WorkspaceStream, appCfg config.Config, clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) (*WorkspaceTriggerWorker, error) {
+	w := NewWorkspaceTriggerWorkerWithoutSubscription(appCfg, clients, tfc, rs)
 	if _, err := stream.QueueSubscribe(w.HandleMsg); err != nil {
 		return nil, fmt.Errorf("could not subscribe to workspace trigger stream: %w", err)
 	}
@@ -42,30 +36,17 @@ func NewWorkspaceTriggerWorker(stream *WorkspaceStream, clients map[string]vcs.G
 }
 
 // NewWorkspaceTriggerWorkerWithoutSubscription constructs a worker without
-// subscribing to a stream. Used by tests that drive HandleMsg directly.
-func NewWorkspaceTriggerWorkerWithoutSubscription(clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) *WorkspaceTriggerWorker {
+// subscribing. Used by tests that drive HandleMsg directly.
+func NewWorkspaceTriggerWorkerWithoutSubscription(appCfg config.Config, clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) *WorkspaceTriggerWorker {
 	cp := make(map[string]vcs.GitClient, len(clients))
 	for k, v := range clients {
 		if v != nil {
 			cp[k] = v
 		}
 	}
-	return &WorkspaceTriggerWorker{clients: cp, tfc: tfc, runstream: rs}
+	return &WorkspaceTriggerWorker{appCfg: appCfg, clients: cp, tfc: tfc, runstream: rs}
 }
 
-// clientFor returns the VCS client matching the message's provider. An
-// unrecognized provider is a configuration bug (the hooks layer is supposed
-// to set Opts.VcsProvider on every enqueue), so we fail loudly rather than
-// silently fall back to a default client and post wrong-API errors to the MR.
-func (w *WorkspaceTriggerWorker) clientFor(provider string) (vcs.GitClient, error) {
-	if c, ok := w.clients[provider]; ok {
-		return c, nil
-	}
-	return nil, fmt.Errorf("no VCS client configured for provider %q", provider)
-}
-
-// HandleMsg processes a single workspace trigger delivery. JetStream calls
-// this via the queue subscription; tests call it directly.
 func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error) {
 	ctx, span := otel.Tracer("TFC").Start(msg.Context(), "WorkspaceTriggerWorker.handle",
 		trace.WithAttributes(
@@ -77,11 +58,10 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 		))
 	defer span.End()
 
-	gl, err := w.clientFor(msg.Opts.VcsProvider)
-	if err != nil {
-		// Without a client we can't even post the failure back, so ACK and
-		// rely on the log + tracing for diagnosis. A redelivery wouldn't help
-		// — the message would still match no provider.
+	gl, ok := w.clients[msg.Opts.VcsProvider]
+	if !ok {
+		// ACK and rely on logs/tracing — a redelivery would still match no provider.
+		err := fmt.Errorf("no VCS client configured for provider %q", msg.Opts.VcsProvider)
 		log.Error().Err(err).
 			Str("workspace", msg.Workspace.Name).
 			Str("project", msg.Opts.ProjectNameWithNamespace).
@@ -92,9 +72,7 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 	}
 
 	defer func() {
-		// Never let a panic propagate into JetStream — that would tear down
-		// the subscription. Treat it like any other failure and surface it on
-		// the MR so the user knows their request didn't go through.
+		// Never propagate panics into JetStream — that tears down the subscription.
 		if r := recover(); r != nil {
 			log.Error().Interface("panic", r).
 				Str("workspace", msg.Workspace.Name).
@@ -116,9 +94,8 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 			Int("mr", msg.Opts.MergeRequestIID).
 			Msg("workspace trigger failed")
 		w.postWorkspaceError(ctx, gl, &msg.Opts, msg.Workspace.Name, err)
-		// Swallow the error and ACK: the user has been notified on the MR.
-		// Retrying would create duplicate discussions/runs, which is exactly
-		// the duplicate-state class of bug this fan-out is meant to prevent.
+		// ACK after notifying the user. Retrying would create duplicate
+		// discussions/runs — the exact bug this fan-out is meant to prevent.
 		return nil
 	}
 	return nil
@@ -133,13 +110,14 @@ func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, gl vcs.GitCli
 		return fmt.Errorf("invalid trigger config: %w", err)
 	}
 	trigger := &TFCTrigger{
+		appCfg:    w.appCfg,
 		gl:        gl,
 		tfc:       w.tfc,
 		runstream: w.runstream,
 		cfg:       cfg,
 	}
 
-	mr, err := trigger.gl.GetMergeRequest(ctx, trigger.GetMergeRequestIID(), trigger.GetProjectNameWithNamespace())
+	mr, err := gl.GetMergeRequest(ctx, trigger.GetMergeRequestIID(), trigger.GetProjectNameWithNamespace())
 	if err != nil {
 		return fmt.Errorf("could not read MergeRequest data from VCS API: %w", err)
 	}
@@ -154,21 +132,12 @@ func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, gl vcs.GitCli
 		}
 	}()
 
-	// Re-check that this workspace's paths haven't moved on the target branch
-	// since the MR diverged. The MR-event worker can't do this cheaply (no
-	// clone), so we do it here per workspace.
-	if blocked, reason, err := trigger.workspaceBlockedByTargetBranch(ctx, mr, repo, &msg.Workspace); err != nil {
-		log.Warn().Err(err).Str("ws", msg.Workspace.Name).Msg("could not evaluate target-branch modifications")
-	} else if blocked {
-		return fmt.Errorf("%s", reason)
-	}
-
 	return trigger.triggerRunForWorkspace(ctx, &msg.Workspace, mr, repo.GetLocalDirectory())
 }
 
-// postWorkspaceError surfaces a workspace failure back to the MR/PR. The
-// per-workspace discussion is only created inside triggerRunForWorkspace, so
-// most failures happen before that and need a top-level comment instead.
+// postWorkspaceError surfaces a workspace failure to the MR. The per-workspace
+// discussion only exists inside triggerRunForWorkspace, so failures before that
+// land as a top-level comment.
 func (w *WorkspaceTriggerWorker) postWorkspaceError(ctx context.Context, gl vcs.GitClient, opts *TFCTriggerOptions, ws string, err error) {
 	if gl == nil {
 		return
@@ -177,28 +146,4 @@ func (w *WorkspaceTriggerWorker) postWorkspaceError(ctx context.Context, gl vcs.
 	if cerr := gl.CreateMergeRequestComment(ctx, opts.MergeRequestIID, opts.ProjectNameWithNamespace, body); cerr != nil {
 		log.Error().Err(cerr).Str("workspace", ws).Msg("could not post workspace error to MR")
 	}
-}
-
-// workspaceBlockedByTargetBranch is a workspace-scoped equivalent of
-// getModifiedWorkspacesOnTargetBranch, kept on TFCTrigger so the per-workspace
-// worker can use it without iterating the whole project config.
-func (t *TFCTrigger) workspaceBlockedByTargetBranch(ctx context.Context, mr vcs.MR, repo vcs.GitRepo, ws *TFCWorkspace) (bool, string, error) {
-	ctx, span := otel.Tracer("TFC").Start(ctx, "workspaceBlockedByTargetBranch")
-	defer span.End()
-
-	if err := repo.FetchUpstreamBranch(mr.GetTargetBranch()); err != nil {
-		return false, "", fmt.Errorf("could not fetch target branch %s: %w", mr.GetTargetBranch(), err)
-	}
-	commonSHA, err := repo.GetMergeBase(mr.GetSourceBranch(), mr.GetTargetBranch())
-	if err != nil {
-		return false, "", fmt.Errorf("could not find merge base: %w", err)
-	}
-	targetModifiedFiles, err := repo.GetModifiedFileNamesBetweenCommits(commonSHA, mr.GetTargetBranch())
-	if err != nil {
-		return false, "", fmt.Errorf("could not list modified files between %s..%s: %w", commonSHA, mr.GetTargetBranch(), err)
-	}
-	if len(targetModifiedFiles) == 0 || !hasChangesForWorkspace(ws, targetModifiedFiles) {
-		return false, "", nil
-	}
-	return true, fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", ws.Dir, ws.TriggerDirs), nil
 }

--- a/pkg/tfc_trigger/workspace_worker.go
+++ b/pkg/tfc_trigger/workspace_worker.go
@@ -19,8 +19,13 @@ import (
 // TFC run per message. Each delivery is processed independently, so the
 // JetStream AckWait window applies per workspace rather than per MR/PR — this
 // is the durability boundary the fan-out provides.
+//
+// The single workspace stream is shared across VCS providers, so the worker
+// keeps a per-provider client map keyed by TFCTriggerOptions.VcsProvider and
+// routes each message to the matching client. Without this, a GitHub-origin
+// trigger would be handled by the GitLab API client and fail consistently.
 type WorkspaceTriggerWorker struct {
-	gl        vcs.GitClient
+	clients   map[string]vcs.GitClient
 	tfc       tfc_api.ApiClient
 	runstream runstream.StreamClient
 }
@@ -28,8 +33,8 @@ type WorkspaceTriggerWorker struct {
 // NewWorkspaceTriggerWorker subscribes to the workspace stream and starts
 // processing messages. The subscription is queue-bound so multiple replicas
 // share the load.
-func NewWorkspaceTriggerWorker(stream *WorkspaceStream, gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) (*WorkspaceTriggerWorker, error) {
-	w := NewWorkspaceTriggerWorkerWithoutSubscription(gl, tfc, rs)
+func NewWorkspaceTriggerWorker(stream *WorkspaceStream, clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) (*WorkspaceTriggerWorker, error) {
+	w := NewWorkspaceTriggerWorkerWithoutSubscription(clients, tfc, rs)
 	if _, err := stream.QueueSubscribe(w.HandleMsg); err != nil {
 		return nil, fmt.Errorf("could not subscribe to workspace trigger stream: %w", err)
 	}
@@ -38,8 +43,25 @@ func NewWorkspaceTriggerWorker(stream *WorkspaceStream, gl vcs.GitClient, tfc tf
 
 // NewWorkspaceTriggerWorkerWithoutSubscription constructs a worker without
 // subscribing to a stream. Used by tests that drive HandleMsg directly.
-func NewWorkspaceTriggerWorkerWithoutSubscription(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) *WorkspaceTriggerWorker {
-	return &WorkspaceTriggerWorker{gl: gl, tfc: tfc, runstream: rs}
+func NewWorkspaceTriggerWorkerWithoutSubscription(clients map[string]vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient) *WorkspaceTriggerWorker {
+	cp := make(map[string]vcs.GitClient, len(clients))
+	for k, v := range clients {
+		if v != nil {
+			cp[k] = v
+		}
+	}
+	return &WorkspaceTriggerWorker{clients: cp, tfc: tfc, runstream: rs}
+}
+
+// clientFor returns the VCS client matching the message's provider. An
+// unrecognized provider is a configuration bug (the hooks layer is supposed
+// to set Opts.VcsProvider on every enqueue), so we fail loudly rather than
+// silently fall back to a default client and post wrong-API errors to the MR.
+func (w *WorkspaceTriggerWorker) clientFor(provider string) (vcs.GitClient, error) {
+	if c, ok := w.clients[provider]; ok {
+		return c, nil
+	}
+	return nil, fmt.Errorf("no VCS client configured for provider %q", provider)
 }
 
 // HandleMsg processes a single workspace trigger delivery. JetStream calls
@@ -51,8 +73,23 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 			attribute.String("project", msg.Opts.ProjectNameWithNamespace),
 			attribute.Int("mr", msg.Opts.MergeRequestIID),
 			attribute.String("action", msg.Opts.Action.String()),
+			attribute.String("vcs_provider", msg.Opts.VcsProvider),
 		))
 	defer span.End()
+
+	gl, err := w.clientFor(msg.Opts.VcsProvider)
+	if err != nil {
+		// Without a client we can't even post the failure back, so ACK and
+		// rely on the log + tracing for diagnosis. A redelivery wouldn't help
+		// — the message would still match no provider.
+		log.Error().Err(err).
+			Str("workspace", msg.Workspace.Name).
+			Str("project", msg.Opts.ProjectNameWithNamespace).
+			Int("mr", msg.Opts.MergeRequestIID).
+			Msg("dropping workspace trigger with unknown VCS provider")
+		span.RecordError(err)
+		return nil
+	}
 
 	defer func() {
 		// Never let a panic propagate into JetStream — that would tear down
@@ -62,18 +99,23 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 			log.Error().Interface("panic", r).
 				Str("workspace", msg.Workspace.Name).
 				Msg("recovered from panic in workspace worker")
-			w.postWorkspaceError(ctx, &msg.Opts, msg.Workspace.Name, fmt.Errorf("internal error: %v", r))
+			span.RecordError(fmt.Errorf("panic recovered: %v", r))
+			userErr := fmt.Errorf("internal error")
+			if traceID := span.SpanContext().TraceID(); traceID.IsValid() {
+				userErr = fmt.Errorf("internal error (trace id: %s)", traceID.String())
+			}
+			w.postWorkspaceError(ctx, gl, &msg.Opts, msg.Workspace.Name, userErr)
 			rerr = nil
 		}
 	}()
 
-	if err := w.runWorkspace(ctx, msg); err != nil {
+	if err := w.runWorkspace(ctx, gl, msg); err != nil {
 		log.Error().Err(err).
 			Str("workspace", msg.Workspace.Name).
 			Str("project", msg.Opts.ProjectNameWithNamespace).
 			Int("mr", msg.Opts.MergeRequestIID).
 			Msg("workspace trigger failed")
-		w.postWorkspaceError(ctx, &msg.Opts, msg.Workspace.Name, err)
+		w.postWorkspaceError(ctx, gl, &msg.Opts, msg.Workspace.Name, err)
 		// Swallow the error and ACK: the user has been notified on the MR.
 		// Retrying would create duplicate discussions/runs, which is exactly
 		// the duplicate-state class of bug this fan-out is meant to prevent.
@@ -82,7 +124,7 @@ func (w *WorkspaceTriggerWorker) HandleMsg(msg *WorkspaceTriggerMsg) (rerr error
 	return nil
 }
 
-func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, msg *WorkspaceTriggerMsg) error {
+func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, gl vcs.GitClient, msg *WorkspaceTriggerMsg) error {
 	ctx, span := otel.Tracer("TFC").Start(ctx, "WorkspaceTriggerWorker.run")
 	defer span.End()
 
@@ -91,7 +133,7 @@ func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, msg *Workspac
 		return fmt.Errorf("invalid trigger config: %w", err)
 	}
 	trigger := &TFCTrigger{
-		gl:        w.gl,
+		gl:        gl,
 		tfc:       w.tfc,
 		runstream: w.runstream,
 		cfg:       cfg,
@@ -106,7 +148,11 @@ func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, msg *Workspac
 	if err != nil {
 		return fmt.Errorf("could not clone repo: %w", err)
 	}
-	defer os.RemoveAll(repo.GetLocalDirectory())
+	defer func() {
+		if err := os.RemoveAll(repo.GetLocalDirectory()); err != nil {
+			log.Error().Err(err).Str("path", repo.GetLocalDirectory()).Msg("could not remove cloned repository directory")
+		}
+	}()
 
 	// Re-check that this workspace's paths haven't moved on the target branch
 	// since the MR diverged. The MR-event worker can't do this cheaply (no
@@ -123,12 +169,12 @@ func (w *WorkspaceTriggerWorker) runWorkspace(ctx context.Context, msg *Workspac
 // postWorkspaceError surfaces a workspace failure back to the MR/PR. The
 // per-workspace discussion is only created inside triggerRunForWorkspace, so
 // most failures happen before that and need a top-level comment instead.
-func (w *WorkspaceTriggerWorker) postWorkspaceError(ctx context.Context, opts *TFCTriggerOptions, ws string, err error) {
-	if w.gl == nil {
+func (w *WorkspaceTriggerWorker) postWorkspaceError(ctx context.Context, gl vcs.GitClient, opts *TFCTriggerOptions, ws string, err error) {
+	if gl == nil {
 		return
 	}
 	body := fmt.Sprintf(":no_entry: %s could not be run because: %s", ws, err.Error())
-	if cerr := w.gl.CreateMergeRequestComment(ctx, opts.MergeRequestIID, opts.ProjectNameWithNamespace, body); cerr != nil {
+	if cerr := gl.CreateMergeRequestComment(ctx, opts.MergeRequestIID, opts.ProjectNameWithNamespace, body); cerr != nil {
 		log.Error().Err(cerr).Str("workspace", ws).Msg("could not post workspace error to MR")
 	}
 }

--- a/pkg/tfc_trigger/workspace_worker_test.go
+++ b/pkg/tfc_trigger/workspace_worker_test.go
@@ -1,0 +1,249 @@
+package tfc_trigger_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zapier/tfbuddy/pkg/mocks"
+	"github.com/zapier/tfbuddy/pkg/runstream"
+	"github.com/zapier/tfbuddy/pkg/tfc_api"
+	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
+	"github.com/zapier/tfbuddy/pkg/vcs"
+)
+
+// TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs drains a
+// fan-out queue concurrently and asserts each per-workspace AddRunMeta carries
+// that workspace's own DiscussionID/RootNoteID. This is the regression guard
+// for the goroutine-local discussion fix — if discussion IDs ever leak across
+// workspaces (the t.cfg race), the assertion below catches it.
+func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testing.T) {
+	const numWorkspaces = 6
+	cfg := buildFanoutWorkspaces(numWorkspaces)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
+
+	// Each workspace gets a unique discussion + note ID so a regression that
+	// shares discussion state across goroutines surfaces as a wrong mapping.
+	// Override default modified-files mock from InitTestSuite so each
+	// workspace dir matches at least one changed file.
+	modified := make([]string, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
+	}
+	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
+
+	wantDisc := map[string]string{}
+	wantNote := map[string]int64{}
+	for i := 0; i < numWorkspaces; i++ {
+		wsName := fmt.Sprintf("service-tfbuddy-%02d", i)
+		discID := fmt.Sprintf("disc-%02d", i)
+		noteID := int64(1000 + i)
+		wantDisc[wsName] = discID
+		wantNote[wsName] = noteID
+
+		dis := mocks.NewMockMRDiscussionNotes(mockCtrl)
+		dis.EXPECT().GetDiscussionID().Return(discID).AnyTimes()
+		note := mocks.NewMockMRNote(mockCtrl)
+		note.EXPECT().GetNoteID().Return(noteID).AnyTimes()
+		dis.EXPECT().GetMRNotes().Return([]vcs.MRNote{note}).AnyTimes()
+		testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(
+			gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS,
+			fmt.Sprintf("Starting TFC apply for Workspace: `zapier-test/%s`.\n<!-- tfbuddy:ws=%s:action=apply -->", wsName, wsName),
+		).Return(dis, nil).Times(1)
+	}
+
+	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", gomock.Any()).DoAndReturn(func(_ context.Context, _, name string) (*tfe.Workspace, error) {
+		return &tfe.Workspace{ID: name}, nil
+	}).AnyTimes()
+
+	// Track in-flight runs to confirm the worker actually processes messages
+	// in parallel (peak >= 2 unless a regression serializes them).
+	var inflight, peak int32
+	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts *tfc_api.ApiRunOptions) (*tfe.Run, error) {
+		cur := atomic.AddInt32(&inflight, 1)
+		for {
+			p := atomic.LoadInt32(&peak)
+			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
+				break
+			}
+		}
+		atomic.AddInt32(&inflight, -1)
+		return &tfe.Run{
+			ID:                   "run-" + opts.Workspace,
+			Workspace:            &tfe.Workspace{Name: opts.Workspace, Organization: &tfe.Organization{Name: "zapier-test"}},
+			ConfigurationVersion: &tfe.ConfigurationVersion{Speculative: false},
+		}, nil
+	}).Times(numWorkspaces)
+
+	// Capture each workspace's metadata as it lands in AddRunMeta. The lock
+	// keeps the assertions safe under -race.
+	var seenMu sync.Mutex
+	seenDisc := make(map[string]string)
+	seenNote := make(map[string]int64)
+	testSuite.MockStreamClient.EXPECT().AddRunMeta(gomock.Any()).DoAndReturn(func(rmd runstream.RunMetadata) error {
+		seenMu.Lock()
+		seenDisc[rmd.GetWorkspace()] = rmd.GetDiscussionID()
+		seenNote[rmd.GetWorkspace()] = rmd.GetRootNoteID()
+		seenMu.Unlock()
+		return nil
+	}).Times(numWorkspaces)
+	testSuite.InitTestSuite()
+
+	// Build the fan-out exactly as production does — TriggerTFCEvents enqueues,
+	// then the worker drains.
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   testSuite.MetaData.SourceBranch,
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+	})
+	pub := &fakeWorkspacePublisher{}
+	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger.SetWorkspaceStream(pub)
+
+	if _, err := trigger.TriggerTFCEvents(context.Background()); err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+
+	// Now drain. This is what NATS would do: invoke HandleMsg on each delivery.
+	// We dispatch them in parallel to exercise the goroutine-local fix.
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+
+	// The worker re-clones the repo and re-checks target-branch modifications
+	// per workspace. The TestSuite's existing mocks already cover those calls
+	// with AnyTimes, so all we need is the inner trigger to succeed.
+	var wg sync.WaitGroup
+	for _, msg := range pub.msgs {
+		msg := msg
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := worker.HandleMsg(msg); err != nil {
+				t.Errorf("worker run for %s failed: %v", msg.Workspace.Name, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	seenMu.Lock()
+	defer seenMu.Unlock()
+	if len(seenDisc) != numWorkspaces {
+		t.Fatalf("expected AddRunMeta for %d workspaces, got %d (%v)", numWorkspaces, len(seenDisc), seenDisc)
+	}
+	for ws, want := range wantDisc {
+		got, ok := seenDisc[ws]
+		if !ok {
+			t.Fatalf("workspace %s did not publish AddRunMeta", ws)
+		}
+		if got != want {
+			t.Fatalf("workspace %s leaked discussionID: got %q, want %q", ws, got, want)
+		}
+		if seenNote[ws] != wantNote[ws] {
+			t.Fatalf("workspace %s leaked rootNoteID: got %d, want %d", ws, seenNote[ws], wantNote[ws])
+		}
+	}
+}
+
+// TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure verifies a workspace
+// failure surfaces back to the MR via a top-level comment and the worker
+// returns nil so the message is ACKed (we deliberately don't NAK because
+// retries would create duplicate discussions and runs).
+func TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
+
+	// VCS API blows up while loading the MR — runWorkspace returns this error
+	// before any clone or discussion happens.
+	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).
+		Return(nil, errors.New("VCS API down")).AnyTimes()
+
+	var posted []string
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestComment(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int, _, body string) error {
+			posted = append(posted, body)
+			return nil
+		}).Times(1)
+
+	testSuite.InitTestSuite()
+
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+	msg := &tfc_trigger.WorkspaceTriggerMsg{
+		Opts: tfc_trigger.TFCTriggerOptions{
+			Action:                   tfc_trigger.PlanAction,
+			ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+			MergeRequestIID:          testSuite.MetaData.MRIID,
+			CommitSHA:                "deadbeef",
+			TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+			VcsProvider:              "gitlab",
+		},
+		Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+	}
+
+	if err := worker.HandleMsg(msg); err != nil {
+		t.Fatalf("HandleMsg should ACK on workspace error, got: %v", err)
+	}
+	if len(posted) != 1 {
+		t.Fatalf("expected 1 MR comment posted, got %d", len(posted))
+	}
+	if !strings.Contains(posted[0], "service-tfbuddy") || !strings.Contains(posted[0], "VCS API down") {
+		t.Fatalf("MR comment should mention workspace and root cause, got: %q", posted[0])
+	}
+}
+
+// TestWorkspaceWorker_RecoversFromPanic confirms a panic inside the worker
+// (e.g. nil pointer in a downstream call) doesn't tear down the JetStream
+// subscription. The worker logs, posts a generic error to the MR, and ACKs.
+func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
+
+	// Force a panic by returning a nil MR — trigger.cloneGitRepo will
+	// dereference it.
+	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).
+		DoAndReturn(func(_ context.Context, _ int, _ string) (vcs.DetailedMR, error) {
+			panic("unexpected nil dereference in test")
+		}).AnyTimes()
+
+	var posted []string
+	testSuite.MockGitClient.EXPECT().CreateMergeRequestComment(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int, _, body string) error {
+			posted = append(posted, body)
+			return nil
+		}).Times(1)
+
+	testSuite.InitTestSuite()
+
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+	msg := &tfc_trigger.WorkspaceTriggerMsg{
+		Opts: tfc_trigger.TFCTriggerOptions{
+			Action:                   tfc_trigger.PlanAction,
+			ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+			MergeRequestIID:          testSuite.MetaData.MRIID,
+			CommitSHA:                "deadbeef",
+			TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+			VcsProvider:              "gitlab",
+		},
+		Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+	}
+
+	if err := worker.HandleMsg(msg); err != nil {
+		t.Fatalf("HandleMsg must swallow panics so JetStream stays subscribed, got: %v", err)
+	}
+	if len(posted) != 1 || !strings.Contains(posted[0], "internal error") {
+		t.Fatalf("expected an internal-error MR comment, got: %v", posted)
+	}
+}

--- a/pkg/tfc_trigger/workspace_worker_test.go
+++ b/pkg/tfc_trigger/workspace_worker_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -66,18 +65,7 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 		return &tfe.Workspace{ID: name}, nil
 	}).AnyTimes()
 
-	// Track in-flight runs to confirm the worker actually processes messages
-	// in parallel (peak >= 2 unless a regression serializes them).
-	var inflight, peak int32
 	testSuite.MockApiClient.EXPECT().CreateRunFromSource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts *tfc_api.ApiRunOptions) (*tfe.Run, error) {
-		cur := atomic.AddInt32(&inflight, 1)
-		for {
-			p := atomic.LoadInt32(&peak)
-			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
-				break
-			}
-		}
-		atomic.AddInt32(&inflight, -1)
 		return &tfe.Run{
 			ID:                   "run-" + opts.Workspace,
 			Workspace:            &tfe.Workspace{Name: opts.Workspace, Organization: &tfe.Organization{Name: "zapier-test"}},
@@ -108,6 +96,7 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+		VcsProvider:              "gitlab",
 	})
 	pub := &fakeWorkspacePublisher{}
 	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
@@ -119,7 +108,10 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 
 	// Now drain. This is what NATS would do: invoke HandleMsg on each delivery.
 	// We dispatch them in parallel to exercise the goroutine-local fix.
-	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
+		testSuite.MockApiClient, testSuite.MockStreamClient,
+	)
 
 	// The worker re-clones the repo and re-checks target-branch modifications
 	// per workspace. The TestSuite's existing mocks already cover those calls
@@ -179,7 +171,10 @@ func TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure(t *testing.T) {
 
 	testSuite.InitTestSuite()
 
-	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
+		testSuite.MockApiClient, testSuite.MockStreamClient,
+	)
 	msg := &tfc_trigger.WorkspaceTriggerMsg{
 		Opts: tfc_trigger.TFCTriggerOptions{
 			Action:                   tfc_trigger.PlanAction,
@@ -227,7 +222,10 @@ func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
 
 	testSuite.InitTestSuite()
 
-	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient)
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
+		testSuite.MockApiClient, testSuite.MockStreamClient,
+	)
 	msg := &tfc_trigger.WorkspaceTriggerMsg{
 		Opts: tfc_trigger.TFCTriggerOptions{
 			Action:                   tfc_trigger.PlanAction,
@@ -245,5 +243,67 @@ func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
 	}
 	if len(posted) != 1 || !strings.Contains(posted[0], "internal error") {
 		t.Fatalf("expected an internal-error MR comment, got: %v", posted)
+	}
+}
+
+// TestWorkspaceWorker_RoutesByVcsProvider locks in the fan-out routing fix:
+// the worker must dispatch to the client matching msg.Opts.VcsProvider, never
+// to the other provider. A regression here would manifest in production as
+// GitHub-origin triggers calling the GitLab API (404s, auth failures, MR
+// comment spam) — exactly the class of bug the multi-client worker prevents.
+func TestWorkspaceWorker_RoutesByVcsProvider(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
+
+	// Two distinct clients so we can prove dispatch picks the right one.
+	// The GitHub mock is the one we expect to receive calls; a stray call
+	// to the GitLab mock would fail the test via gomock's strict mode.
+	githubClient := mocks.NewMockGitClient(mockCtrl)
+	gitlabClient := mocks.NewMockGitClient(mockCtrl)
+
+	githubClient.EXPECT().GetMergeRequest(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).
+		Return(nil, errors.New("forced failure to short-circuit run path")).Times(1)
+	githubClient.EXPECT().CreateMergeRequestComment(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS, gomock.Any()).
+		Return(nil).Times(1)
+
+	testSuite.InitTestSuite()
+
+	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		map[string]vcs.GitClient{"gitlab": gitlabClient, "github": githubClient},
+		testSuite.MockApiClient, testSuite.MockStreamClient,
+	)
+
+	githubMsg := &tfc_trigger.WorkspaceTriggerMsg{
+		Opts: tfc_trigger.TFCTriggerOptions{
+			Action:                   tfc_trigger.PlanAction,
+			ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+			MergeRequestIID:          testSuite.MetaData.MRIID,
+			CommitSHA:                "deadbeef",
+			TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+			VcsProvider:              "github",
+		},
+		Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+	}
+	if err := worker.HandleMsg(githubMsg); err != nil {
+		t.Fatalf("HandleMsg should ACK on workspace error, got: %v", err)
+	}
+
+	// Unknown provider must be dropped (ACKed) without invoking either
+	// client — there's nothing actionable we can do, and using a default
+	// would corrupt the receiving VCS.
+	unknownMsg := &tfc_trigger.WorkspaceTriggerMsg{
+		Opts: tfc_trigger.TFCTriggerOptions{
+			Action:                   tfc_trigger.PlanAction,
+			ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+			MergeRequestIID:          testSuite.MetaData.MRIID,
+			CommitSHA:                "deadbeef",
+			TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
+			VcsProvider:              "bitbucket",
+		},
+		Workspace: tfc_trigger.TFCWorkspace{Name: "service-tfbuddy", Organization: "zapier-test"},
+	}
+	if err := worker.HandleMsg(unknownMsg); err != nil {
+		t.Fatalf("HandleMsg should ACK on unknown provider, got: %v", err)
 	}
 }

--- a/pkg/tfc_trigger/workspace_worker_test.go
+++ b/pkg/tfc_trigger/workspace_worker_test.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"go.uber.org/mock/gomock"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/mocks"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
@@ -18,11 +20,9 @@ import (
 	"github.com/zapier/tfbuddy/pkg/vcs"
 )
 
-// TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs drains a
-// fan-out queue concurrently and asserts each per-workspace AddRunMeta carries
-// that workspace's own DiscussionID/RootNoteID. This is the regression guard
-// for the goroutine-local discussion fix — if discussion IDs ever leak across
-// workspaces (the t.cfg race), the assertion below catches it.
+// TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs guards the
+// goroutine-local discussion fix: each AddRunMeta must carry its workspace's
+// own IDs, and peak inflight must exceed 1 (proving parallel drain).
 func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testing.T) {
 	const numWorkspaces = 6
 	cfg := buildFanoutWorkspaces(numWorkspaces)
@@ -31,16 +31,16 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: cfg}, t)
 
-	// Each workspace gets a unique discussion + note ID so a regression that
-	// shares discussion state across goroutines surfaces as a wrong mapping.
-	// Override default modified-files mock from InitTestSuite so each
-	// workspace dir matches at least one changed file.
+	// Override default modified-files mock so each workspace dir matches.
 	modified := make([]string, 0, numWorkspaces)
 	for i := 0; i < numWorkspaces; i++ {
 		modified = append(modified, fmt.Sprintf("services/svc%02d/main.tf", i))
 	}
 	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return(modified, nil).AnyTimes()
 
+	// peak >= 2 proves the worker drains messages in parallel.
+	var inflightMu sync.Mutex
+	var inflight, peak int
 	wantDisc := map[string]string{}
 	wantNote := map[string]int64{}
 	for i := 0; i < numWorkspaces; i++ {
@@ -58,7 +58,20 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 		testSuite.MockGitClient.EXPECT().CreateMergeRequestDiscussion(
 			gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS,
 			fmt.Sprintf("Starting TFC apply for Workspace: `zapier-test/%s`.\n<!-- tfbuddy:ws=%s:action=apply -->", wsName, wsName),
-		).Return(dis, nil).Times(1)
+		).DoAndReturn(func(_ context.Context, _ int, _, _ string) (vcs.MRDiscussionNotes, error) {
+			inflightMu.Lock()
+			inflight++
+			if inflight > peak {
+				peak = inflight
+			}
+			inflightMu.Unlock()
+			// Hold so other goroutines overlap before this one exits.
+			time.Sleep(20 * time.Millisecond)
+			inflightMu.Lock()
+			inflight--
+			inflightMu.Unlock()
+			return dis, nil
+		}).Times(1)
 	}
 
 	testSuite.MockApiClient.EXPECT().GetWorkspaceByName(gomock.Any(), "zapier-test", gomock.Any()).DoAndReturn(func(_ context.Context, _, name string) (*tfe.Workspace, error) {
@@ -73,8 +86,6 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 		}, nil
 	}).Times(numWorkspaces)
 
-	// Capture each workspace's metadata as it lands in AddRunMeta. The lock
-	// keeps the assertions safe under -race.
 	var seenMu sync.Mutex
 	seenDisc := make(map[string]string)
 	seenNote := make(map[string]int64)
@@ -87,8 +98,6 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 	}).Times(numWorkspaces)
 	testSuite.InitTestSuite()
 
-	// Build the fan-out exactly as production does — TriggerTFCEvents enqueues,
-	// then the worker drains.
 	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
 		Action:                   tfc_trigger.ApplyAction,
 		Branch:                   testSuite.MetaData.SourceBranch,
@@ -99,23 +108,19 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 		VcsProvider:              "gitlab",
 	})
 	pub := &fakeWorkspacePublisher{}
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.Config{}, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	trigger.SetWorkspaceStream(pub)
 
 	if _, err := trigger.TriggerTFCEvents(context.Background()); err != nil {
 		t.Fatalf("enqueue failed: %v", err)
 	}
 
-	// Now drain. This is what NATS would do: invoke HandleMsg on each delivery.
-	// We dispatch them in parallel to exercise the goroutine-local fix.
 	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		config.Config{},
 		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
 		testSuite.MockApiClient, testSuite.MockStreamClient,
 	)
 
-	// The worker re-clones the repo and re-checks target-branch modifications
-	// per workspace. The TestSuite's existing mocks already cover those calls
-	// with AnyTimes, so all we need is the inner trigger to succeed.
 	var wg sync.WaitGroup
 	for _, msg := range pub.msgs {
 		msg := msg
@@ -146,19 +151,21 @@ func TestWorkspaceWorker_DrainsConcurrentlyWithoutLeakingDiscussionIDs(t *testin
 			t.Fatalf("workspace %s leaked rootNoteID: got %d, want %d", ws, seenNote[ws], wantNote[ws])
 		}
 	}
+	inflightMu.Lock()
+	gotPeak := peak
+	inflightMu.Unlock()
+	if gotPeak < 2 {
+		t.Fatalf("workspace worker did not drain in parallel: peak inflight=%d, want >= 2", gotPeak)
+	}
 }
 
-// TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure verifies a workspace
-// failure surfaces back to the MR via a top-level comment and the worker
-// returns nil so the message is ACKed (we deliberately don't NAK because
-// retries would create duplicate discussions and runs).
+// TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure asserts that a failure
+// posts to the MR and HandleMsg returns nil (ACK), so retries don't duplicate.
 func TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
 
-	// VCS API blows up while loading the MR — runWorkspace returns this error
-	// before any clone or discussion happens.
 	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).
 		Return(nil, errors.New("VCS API down")).AnyTimes()
 
@@ -172,6 +179,7 @@ func TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure(t *testing.T) {
 	testSuite.InitTestSuite()
 
 	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		config.Config{},
 		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
 		testSuite.MockApiClient, testSuite.MockStreamClient,
 	)
@@ -198,16 +206,13 @@ func TestWorkspaceWorker_PostsErrorToMRAndACKsOnFailure(t *testing.T) {
 	}
 }
 
-// TestWorkspaceWorker_RecoversFromPanic confirms a panic inside the worker
-// (e.g. nil pointer in a downstream call) doesn't tear down the JetStream
-// subscription. The worker logs, posts a generic error to the MR, and ACKs.
+// TestWorkspaceWorker_RecoversFromPanic asserts panics are recovered, surfaced
+// as a generic MR comment, and ACKed.
 func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
 
-	// Force a panic by returning a nil MR — trigger.cloneGitRepo will
-	// dereference it.
 	testSuite.MockGitClient.EXPECT().GetMergeRequest(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).
 		DoAndReturn(func(_ context.Context, _ int, _ string) (vcs.DetailedMR, error) {
 			panic("unexpected nil dereference in test")
@@ -223,6 +228,7 @@ func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
 	testSuite.InitTestSuite()
 
 	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		config.Config{},
 		map[string]vcs.GitClient{"gitlab": testSuite.MockGitClient},
 		testSuite.MockApiClient, testSuite.MockStreamClient,
 	)
@@ -246,19 +252,15 @@ func TestWorkspaceWorker_RecoversFromPanic(t *testing.T) {
 	}
 }
 
-// TestWorkspaceWorker_RoutesByVcsProvider locks in the fan-out routing fix:
-// the worker must dispatch to the client matching msg.Opts.VcsProvider, never
-// to the other provider. A regression here would manifest in production as
-// GitHub-origin triggers calling the GitLab API (404s, auth failures, MR
-// comment spam) — exactly the class of bug the multi-client worker prevents.
+// TestWorkspaceWorker_RoutesByVcsProvider asserts dispatch matches
+// msg.Opts.VcsProvider and unknown providers are dropped (ACKed) without
+// invoking either client.
 func TestWorkspaceWorker_RoutesByVcsProvider(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
 
-	// Two distinct clients so we can prove dispatch picks the right one.
-	// The GitHub mock is the one we expect to receive calls; a stray call
-	// to the GitLab mock would fail the test via gomock's strict mode.
+	// Stray calls to the GitLab mock fail the test under gomock's strict mode.
 	githubClient := mocks.NewMockGitClient(mockCtrl)
 	gitlabClient := mocks.NewMockGitClient(mockCtrl)
 
@@ -270,6 +272,7 @@ func TestWorkspaceWorker_RoutesByVcsProvider(t *testing.T) {
 	testSuite.InitTestSuite()
 
 	worker := tfc_trigger.NewWorkspaceTriggerWorkerWithoutSubscription(
+		config.Config{},
 		map[string]vcs.GitClient{"gitlab": gitlabClient, "github": githubClient},
 		testSuite.MockApiClient, testSuite.MockStreamClient,
 	)
@@ -289,9 +292,6 @@ func TestWorkspaceWorker_RoutesByVcsProvider(t *testing.T) {
 		t.Fatalf("HandleMsg should ACK on workspace error, got: %v", err)
 	}
 
-	// Unknown provider must be dropped (ACKed) without invoking either
-	// client — there's nothing actionable we can do, and using a default
-	// would corrupt the receiving VCS.
 	unknownMsg := &tfc_trigger.WorkspaceTriggerMsg{
 		Opts: tfc_trigger.TFCTriggerOptions{
 			Action:                   tfc_trigger.PlanAction,

--- a/pkg/vcs/github/hooks/github_hooks_handler.go
+++ b/pkg/vcs/github/hooks/github_hooks_handler.go
@@ -108,7 +108,10 @@ func (h *GithubHooksHandler) handleIssueCommentCreatedEvent(deliveryID string, e
 		"eventType":  eventName,
 		"repository": *event.Repo.FullName,
 	}
-	_, err := h.commentStream.Publish(ctx, &GithubIssueCommentEventMsg{Payload: event})
+	_, err := h.commentStream.Publish(ctx, &GithubIssueCommentEventMsg{
+		Payload:    event,
+		DeliveryID: deliveryID,
+	})
 	if err != nil {
 		githubWebHookFailed.With(lbls).Inc()
 	}

--- a/pkg/vcs/github/hooks/github_hooks_handler.go
+++ b/pkg/vcs/github/hooks/github_hooks_handler.go
@@ -36,13 +36,14 @@ type GithubHooksHandler struct {
 	js              nats.JetStreamContext
 	ghEvents        *githubevents.EventHandler
 	triggerCreation TriggerCreationFunc
+	workspaceStream tfc_trigger.WorkspacePublisher
 
 	// streams
 	prStream      *gongs.GenericStream[PullRequestEventMsg, *PullRequestEventMsg]
 	commentStream *gongs.GenericStream[GithubIssueCommentEventMsg, *GithubIssueCommentEventMsg]
 }
 
-func NewGithubHooksHandler(cfg config.Config, vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GithubHooksHandler {
+func NewGithubHooksHandler(cfg config.Config, vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext, workspaceStream tfc_trigger.WorkspacePublisher) *GithubHooksHandler {
 	prStream := gongs.NewGenericStream[PullRequestEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(PullRequestEventType))
 	commentStream := gongs.NewGenericStream[GithubIssueCommentEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(IssueCommentEvent))
 
@@ -55,6 +56,7 @@ func NewGithubHooksHandler(cfg config.Config, vcs vcs.GitClient, tfc tfc_api.Api
 		commentStream:   commentStream,
 		prStream:        prStream,
 		triggerCreation: tfc_trigger.NewTFCTrigger,
+		workspaceStream: workspaceStream,
 	}
 
 	ghEvents := githubevents.New(cfg.GithubHookSecretKey)

--- a/pkg/vcs/github/hooks/stream_types.go
+++ b/pkg/vcs/github/hooks/stream_types.go
@@ -66,8 +66,11 @@ const IssueCommentEvent = "IssueCommentEvent"
 
 type GithubIssueCommentEventMsg struct {
 	Payload *github.IssueCommentEvent `json:"payload"`
-	Carrier propagation.MapCarrier    `json:"Carrier"`
-	Context context.Context
+	// DeliveryID is the X-GitHub-Delivery header; anchors the workspace
+	// fan-out dedup key to the upstream webhook.
+	DeliveryID string                 `json:"deliveryID"`
+	Carrier    propagation.MapCarrier `json:"Carrier"`
+	Context    context.Context
 }
 
 func (e *GithubIssueCommentEventMsg) GetId(ctx context.Context) string {

--- a/pkg/vcs/github/hooks/stream_worker.go
+++ b/pkg/vcs/github/hooks/stream_worker.go
@@ -86,6 +86,9 @@ func (h *GithubHooksHandler) processIssueComment(ctx context.Context, msg *Githu
 	}
 
 	trigger := h.triggerCreation(h.cfg, h.vcs, h.tfc, h.runstream, cfg)
+	if h.workspaceStream != nil {
+		trigger.SetWorkspaceStream(h.workspaceStream)
+	}
 
 	//// TODO: support additional commands and arguments (e.g. destroy, refresh, lock, unlock)
 	//// TODO: this should be refactored and be agnostic to the VCS type

--- a/pkg/vcs/github/hooks/stream_worker.go
+++ b/pkg/vcs/github/hooks/stream_worker.go
@@ -78,6 +78,7 @@ func (h *GithubHooksHandler) processIssueComment(ctx context.Context, msg *Githu
 	opts.TriggerOpts.MergeRequestIID = *event.Issue.Number
 	opts.TriggerOpts.TriggerSource = tfc_trigger.CommentTrigger
 	opts.TriggerOpts.VcsProvider = "github"
+	opts.TriggerOpts.DeliveryID = msg.DeliveryID
 
 	cfg, err := tfc_trigger.NewTFCTriggerConfig(opts.TriggerOpts)
 	if err != nil {
@@ -114,7 +115,7 @@ func (h *GithubHooksHandler) processIssueComment(ctx context.Context, msg *Githu
 		return fmt.Errorf("could not parse command")
 	}
 	executedWorkspaces, tfError := trigger.TriggerTFCEvents(ctx)
-	if tfError == nil && len(executedWorkspaces.Errored) > 0 {
+	if tfError == nil && executedWorkspaces != nil && len(executedWorkspaces.Errored) > 0 {
 		for _, failedWS := range executedWorkspaces.Errored {
 			h.postPullRequestComment(ctx, event, fmt.Sprintf(":no_entry: %s could not be run because: %s", failedWS.Name, failedWS.Error))
 		}


### PR DESCRIPTION
### Description
TFBuddy plan and apply events failed when an MR/PR touched many Terraform workspaces. `TriggerTFCEvents` processed workspaces sequentially inside the JetStream subscriber, so a batch of 5+ workspaces could exceed the default 30s `AckWait`. JetStream then redelivered the message and the duplicate workers raced on the same MR, leaving runs half-created with incomplete comments.

This MR replaces the synchronous loop with a fire-and-forget fan-out. The previous attempt at fixing this (#57) capped concurrency with an `errgroup` but kept everything inline, which only narrowed the timeout window without eliminating the AckWait class of failure.

### Testing

- `go test -race ./pkg/tfc_trigger/... ./pkg/tfc_api/...` — clean.
- End-to-end validated against a kind cluster with live NATS: `tilt up` brings up tfbuddy + NATS, the new stream and `tfbuddy_workspace_trigger_worker` consumer are registered on first boot, and a separate integration smoke test confirmed publish/subscribe + dedup behave correctly across "replicas" of the queue.