### PR TITLE
refactor: route tfbuddy-owned config through viper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 }
 
 func resolveLogLevel() zerolog.Level {
-	lvl, err := zerolog.ParseLevel(config.LogLevel())
+	lvl, err := zerolog.ParseLevel(config.C.LogLevel)
 	if err != nil {
 		log.Println("could not parse log level, defaulting to 'info'")
 		lvl = zerolog.InfoLevel
@@ -56,9 +56,9 @@ func init() {
 
 func initTelemetry(ctx context.Context) (*telemetry.OperatorTelemetry, error) {
 	return telemetry.Init(ctx, "tfbuddy", telemetry.Options{
-		Enabled:   config.OTELEnabled(),
-		Host:      config.OTELCollectorHost(),
-		Port:      config.OTELCollectorPort(),
+		Enabled:   config.C.OTELEnabled,
+		Host:      config.C.OTELCollectorHost,
+		Port:      config.C.OTELCollectorPort,
 		Version:   pkg.GitTag,
 		CommitSHA: pkg.GitCommit,
 	})
@@ -84,4 +84,5 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+	config.Reload()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,12 +25,19 @@ var rootCmd = &cobra.Command{
 	Short: "Various utilties to aid Terraform CI pipelines & Terraform Cloud runs",
 	Long:  ``,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		logging.SetupLogOutput(resolveLogLevel())
+		cfg := loadConfig()
+		logging.SetupLogOutput(cfg.DevMode, resolveLogLevel(cfg))
 	},
 }
 
-func resolveLogLevel() zerolog.Level {
-	lvl, err := zerolog.ParseLevel(config.C.LogLevel)
+func loadConfig() config.Config {
+	cfg, err := config.Load()
+	cobra.CheckErr(err)
+	return cfg
+}
+
+func resolveLogLevel(cfg config.Config) zerolog.Level {
+	lvl, err := zerolog.ParseLevel(cfg.LogLevel)
 	if err != nil {
 		log.Println("could not parse log level, defaulting to 'info'")
 		lvl = zerolog.InfoLevel
@@ -41,7 +48,6 @@ func resolveLogLevel() zerolog.Level {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	logging.SetupLogOutput(resolveLogLevel())
 	cobra.CheckErr(rootCmd.Execute())
 }
 
@@ -50,14 +56,13 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	cobra.CheckErr(config.RegisterFlags(rootCmd.PersistentFlags()))
-	config.Reload()
 }
 
-func initTelemetry(ctx context.Context) (*telemetry.OperatorTelemetry, error) {
+func initTelemetry(ctx context.Context, cfg config.Config) (*telemetry.OperatorTelemetry, error) {
 	return telemetry.Init(ctx, "tfbuddy", telemetry.Options{
-		Enabled:   config.C.OTELEnabled,
-		Host:      config.C.OTELCollectorHost,
-		Port:      config.C.OTELCollectorPort,
+		Enabled:   cfg.OTELEnabled,
+		Host:      cfg.OTELCollectorHost,
+		Port:      cfg.OTELCollectorPort,
 		Version:   pkg.GitTag,
 		CommitSHA: pkg.GitCommit,
 	})
@@ -83,5 +88,4 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
-	config.Reload()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ import (
 )
 
 var cfgFile string
-var logLevel string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -50,8 +49,8 @@ func init() {
 	config.Init()
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "info", "Set the log output level (info, debug, trace)")
-	cobra.CheckErr(viper.BindPFlag(config.KeyLogLevel, rootCmd.PersistentFlags().Lookup("log-level")))
+	cobra.CheckErr(config.RegisterFlags(rootCmd.PersistentFlags()))
+	config.Reload()
 }
 
 func initTelemetry(ctx context.Context) (*telemetry.OperatorTelemetry, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/internal/logging"
 	"github.com/zapier/tfbuddy/internal/telemetry"
 	"github.com/zapier/tfbuddy/pkg"
@@ -32,12 +31,7 @@ var rootCmd = &cobra.Command{
 }
 
 func resolveLogLevel() zerolog.Level {
-	logLevelEnv := os.Getenv("TFBUDDY_LOG_LEVEL")
-	if logLevelEnv != "" {
-		logLevel = logLevelEnv
-	}
-
-	lvl, err := zerolog.ParseLevel(logLevel)
+	lvl, err := zerolog.ParseLevel(config.LogLevel())
 	if err != nil {
 		log.Println("could not parse log level, defaulting to 'info'")
 		lvl = zerolog.InfoLevel
@@ -53,21 +47,18 @@ func Execute() {
 }
 
 func init() {
+	config.Init()
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "info", "Set the log output level (info, debug, trace)")
+	cobra.CheckErr(viper.BindPFlag(config.KeyLogLevel, rootCmd.PersistentFlags().Lookup("log-level")))
 }
 
 func initTelemetry(ctx context.Context) (*telemetry.OperatorTelemetry, error) {
-	enableOtel, err := strconv.ParseBool(os.Getenv("TFBUDDY_OTEL_ENABLED"))
-	if err != nil {
-		log.Printf("could not parse env var TFBUDDY_OTEL_ENABLED, defaulting to false: %v", err)
-		enableOtel = false
-	}
 	return telemetry.Init(ctx, "tfbuddy", telemetry.Options{
-		Enabled:   enableOtel,
-		Host:      os.Getenv("TFBUDDY_OTEL_COLLECTOR_HOST"),
-		Port:      os.Getenv("TFBUDDY_OTEL_COLLECTOR_PORT"),
+		Enabled:   config.OTELEnabled(),
+		Host:      config.OTELCollectorHost(),
+		Port:      config.OTELCollectorPort(),
 		Version:   pkg.GitTag,
 		CommitSHA: pkg.GitCommit,
 	})
@@ -88,10 +79,6 @@ func initConfig() {
 		viper.SetConfigType("yaml")
 		viper.SetConfigName(".tfbuddy")
 	}
-
-	viper.SetEnvPrefix("TFBUDDY")
-	viper.EnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/cmd/tfc_hook_handler.go
+++ b/cmd/tfc_hook_handler.go
@@ -20,14 +20,15 @@ var tfcHookHandlerCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
+		cfg := loadConfig()
 
-		t, err := initTelemetry(ctx)
+		t, err := initTelemetry(ctx, cfg)
 		if err != nil {
 			panic(err)
 		}
 		defer t.Shutdown()
 
-		hooks.StartServer()
+		hooks.StartServer(cfg)
 
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/superpowers/plans/2026-05-07-viper-owned-config.md
+++ b/docs/superpowers/plans/2026-05-07-viper-owned-config.md
@@ -1,0 +1,127 @@
+# Viper-Owned Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route every TFBuddy-owned configuration read through Viper instead of direct environment access.
+
+**Architecture:** Add a small `internal/config` package that defines canonical keys, defaults, and typed getters on top of Viper. Migrate repo-owned call sites to that package while leaving external credentials and CI variables untouched.
+
+**Tech Stack:** Go, Cobra, Viper, Go test
+
+---
+
+### Task 1: Add the config access layer
+
+**Files:**
+- Create: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+- parsing comma-separated lists with trimming and empty item removal
+- bool defaults for auto-merge, delete-old-comments, dev mode, and sentinel soft-fail
+- string fallback behavior for values like NATS URL
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/config`
+Expected: FAIL because the package and helpers do not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add the config package with:
+- canonical keys/constants for TFBuddy-owned settings
+- `Init()` to register defaults
+- typed getters for strings, bools, and string lists
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/config`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add cmd/root.go internal/config/config.go internal/config/config_test.go
+git commit -m "refactor: add viper-backed config accessors"
+```
+
+### Task 2: Migrate owned config call sites
+
+**Files:**
+- Modify: `cmd/root.go`
+- Modify: `internal/logging/logging.go`
+- Modify: `pkg/allow_list/common.go`
+- Modify: `pkg/comment_formatter/tfc_status_update.go`
+- Modify: `pkg/gitlab_hooks/handler.go`
+- Modify: `pkg/nats/nats_client.go`
+- Modify: `pkg/tfc_trigger/project_config.go`
+- Modify: `pkg/tfc_trigger/workspace_allowdeny_list.go`
+- Modify: `pkg/vcs/common.go`
+- Modify: `pkg/vcs/github/client.go`
+- Modify: `pkg/vcs/github/hooks/github_hooks_handler.go`
+- Modify: `pkg/vcs/gitlab/client.go`
+- Modify: `pkg/vcs/gitlab/mr_status_updater.go`
+
+- [ ] **Step 1: Write targeted failing tests or extend existing coverage**
+
+Focus on:
+- workspace allow/deny parsing
+- global auto-merge default semantics
+- delete-old-comments bool behavior
+
+- [ ] **Step 2: Run the targeted tests to verify failure**
+
+Run:
+```bash
+go test ./pkg/tfc_trigger ./pkg/vcs ./pkg/vcs/github ./pkg/vcs/gitlab
+```
+Expected: FAIL or require test updates because migrated accessors are not wired yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Replace direct `os.Getenv("TFBUDDY_*")` reads with the new config helpers, preserving current defaults and messages.
+
+- [ ] **Step 4: Run the targeted tests to verify they pass**
+
+Run:
+```bash
+go test ./pkg/tfc_trigger ./pkg/vcs ./pkg/vcs/github ./pkg/vcs/gitlab
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add cmd/root.go internal/logging/logging.go pkg/allow_list/common.go pkg/comment_formatter/tfc_status_update.go pkg/gitlab_hooks/handler.go pkg/nats/nats_client.go pkg/tfc_trigger/project_config.go pkg/tfc_trigger/workspace_allowdeny_list.go pkg/vcs/common.go pkg/vcs/github/client.go pkg/vcs/github/hooks/github_hooks_handler.go pkg/vcs/gitlab/client.go pkg/vcs/gitlab/mr_status_updater.go
+git commit -m "refactor: route tfbuddy config through viper"
+```
+
+### Task 3: Verify the migration end to end
+
+**Files:**
+- Modify: `README.md` if config docs need cleanup
+
+- [ ] **Step 1: Run full verification**
+
+Run:
+```bash
+go test ./...
+```
+Expected: PASS
+
+- [ ] **Step 2: Update docs only if needed**
+
+If any user-facing config wording now needs clarification, update `README.md` or leave docs unchanged.
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add README.md
+git commit -m "docs: clarify viper-backed tfbuddy config" || true
+```

--- a/docs/superpowers/specs/2026-05-07-viper-owned-config-design.md
+++ b/docs/superpowers/specs/2026-05-07-viper-owned-config-design.md
@@ -1,0 +1,87 @@
+# Viper-Owned Config Design
+
+**Date:** 2026-05-07
+
+## Goal
+
+Replace direct reads of TFBuddy-owned environment variables with Viper-backed configuration so repo-owned settings follow one consistent access path.
+
+## Scope
+
+In scope:
+
+- `TFBUDDY_*` settings owned by this repo
+- Parsed booleans, strings, and comma-separated lists currently read with `os.Getenv`
+- Default handling for repo-owned settings
+
+Out of scope:
+
+- Provider credentials such as `TFC_TOKEN`, `TFE_TOKEN`, `GITHUB_TOKEN`, `GITLAB_TOKEN`, and `GITLAB_ACCESS_TOKEN`
+- Runtime CI variables such as `CI_PROJECT_ID`, `CI_COMMIT_SHA`, and `CI_MERGE_REQUEST_IID`
+- Terraform Cloud workspace selection variables such as `TFC_WORKSPACE_NAME`
+
+## Current Problems
+
+- Viper is initialized centrally in `cmd/root.go`, but many packages bypass it and read `os.Getenv` directly.
+- Boolean parsing is duplicated and inconsistent.
+- Comma-separated list parsing lives at call sites instead of in one config layer.
+- Raw config key strings are spread across the codebase.
+
+## Proposed Approach
+
+Introduce a small `internal/config` package backed by Viper that exposes typed helpers for TFBuddy-owned configuration.
+
+Responsibilities:
+
+- Define canonical config key names for repo-owned settings
+- Bind defaults in one place
+- Provide typed accessors for booleans, strings, and lists
+- Keep parsing behavior consistent and close to Viper
+
+Call sites that currently use `os.Getenv("TFBUDDY_*")` will switch to this package. Non-owned environment variables remain untouched.
+
+## Initial Config Surface
+
+- Logging:
+  - `TFBUDDY_LOG_LEVEL`
+  - `TFBUDDY_DEV_MODE`
+- Telemetry:
+  - `TFBUDDY_OTEL_ENABLED`
+  - `TFBUDDY_OTEL_COLLECTOR_HOST`
+  - `TFBUDDY_OTEL_COLLECTOR_PORT`
+- Hooks:
+  - `TFBUDDY_GITLAB_HOOK_SECRET_KEY`
+  - `TFBUDDY_GITHUB_HOOK_SECRET_KEY`
+- Trigger behavior:
+  - `TFBUDDY_DEFAULT_TFC_ORGANIZATION`
+  - `TFBUDDY_WORKSPACE_ALLOW_LIST`
+  - `TFBUDDY_WORKSPACE_DENY_LIST`
+  - `TFBUDDY_ALLOW_AUTO_MERGE`
+- Comment/status behavior:
+  - `TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL`
+  - `TFBUDDY_DELETE_OLD_COMMENTS`
+- Runtime wiring:
+  - `TFBUDDY_NATS_SERVICE_URL`
+
+## Implementation Notes
+
+- Keep Viper initialization in `cmd/root.go`.
+- Add one config initialization function that sets defaults after `viper.AutomaticEnv()`.
+- Prefer Viper accessors over re-parsing string env values at call sites.
+- For list values, use a helper that trims whitespace and drops empty items.
+- Preserve existing behavior where default semantics matter, especially:
+  - auto-merge enabled unless explicitly set to `false`
+  - NATS URL falls back to `nats.DefaultURL`
+  - sentinel soft-fail remains false unless explicitly enabled
+
+## Testing
+
+- Add unit coverage for list parsing and bool/default behavior in the new config package.
+- Update or add targeted tests for packages whose behavior depends on migrated settings.
+- Run the full Go test suite after the migration.
+
+## Risks
+
+- Viper key naming can drift if accessors and env bindings do not agree.
+- Changing bool parsing semantics could subtly alter defaults if not preserved.
+- Some code paths may rely on empty string versus unset behavior; tests should lock that down.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -56,28 +58,30 @@ var C Config
 type binding struct {
 	key          string
 	defaultValue any
+	description  string
+	shorthand    string
 }
 
 var bindings = []binding{
-	{key: KeyLogLevel, defaultValue: "info"},
-	{key: KeyDevMode, defaultValue: false},
-	{key: KeyOTELEnabled, defaultValue: false},
-	{key: KeyOTELCollectorHost, defaultValue: ""},
-	{key: KeyOTELCollectorPort, defaultValue: ""},
-	{key: KeyGitlabHookSecretKey, defaultValue: ""},
-	{key: KeyGithubHookSecretKey, defaultValue: ""},
-	{key: KeyDefaultTFCOrganization, defaultValue: ""},
-	{key: KeyWorkspaceAllowList, defaultValue: []string{}},
-	{key: KeyWorkspaceDenyList, defaultValue: []string{}},
-	{key: KeyAllowAutoMerge, defaultValue: true},
-	{key: KeyFailCIOnSentinelSoftFail, defaultValue: false},
-	{key: KeyDeleteOldComments, defaultValue: false},
-	{key: KeyNATSServiceURL, defaultValue: ""},
-	{key: KeyGitlabProjectAllowList, defaultValue: []string{}},
-	{key: KeyLegacyProjectAllowList, defaultValue: []string{}},
-	{key: KeyGithubRepoAllowList, defaultValue: []string{}},
-	{key: KeyGithubCloneDepth, defaultValue: 0},
-	{key: KeyGitlabCloneDepth, defaultValue: 0},
+	{key: KeyLogLevel, defaultValue: "info", description: "Set the log output level (info, debug, trace)", shorthand: "v"},
+	{key: KeyDevMode, defaultValue: false, description: "Enable developer-friendly console logging output."},
+	{key: KeyOTELEnabled, defaultValue: false, description: "Enable OpenTelemetry export for TFBuddy."},
+	{key: KeyOTELCollectorHost, defaultValue: "", description: "OpenTelemetry collector host."},
+	{key: KeyOTELCollectorPort, defaultValue: "", description: "OpenTelemetry collector port."},
+	{key: KeyGitlabHookSecretKey, defaultValue: "", description: "Secret key used to validate incoming GitLab webhooks."},
+	{key: KeyGithubHookSecretKey, defaultValue: "", description: "Secret key used to validate incoming GitHub webhooks."},
+	{key: KeyDefaultTFCOrganization, defaultValue: "", description: "Default Terraform Cloud organization for workspaces that omit one in .tfbuddy.yaml."},
+	{key: KeyWorkspaceAllowList, defaultValue: []string{}, description: "Comma-separated workspace allow list. Entries without an organization use the default Terraform Cloud organization."},
+	{key: KeyWorkspaceDenyList, defaultValue: []string{}, description: "Comma-separated workspace deny list. Entries without an organization use the default Terraform Cloud organization."},
+	{key: KeyAllowAutoMerge, defaultValue: true, description: "Globally enable or disable TFBuddy-managed auto-merge."},
+	{key: KeyFailCIOnSentinelSoftFail, defaultValue: false, description: "Mark CI as failed when Terraform policy checks soft-fail."},
+	{key: KeyDeleteOldComments, defaultValue: false, description: "Delete older bot comments for the same workspace and action after posting a newer one."},
+	{key: KeyNATSServiceURL, defaultValue: "", description: "NATS connection URL. When empty, TFBuddy falls back to the NATS client default."},
+	{key: KeyGitlabProjectAllowList, defaultValue: []string{}, description: "Comma-separated GitLab project allow list prefixes."},
+	{key: KeyLegacyProjectAllowList, defaultValue: []string{}, description: "Deprecated comma-separated GitLab project allow list prefixes."},
+	{key: KeyGithubRepoAllowList, defaultValue: []string{}, description: "Comma-separated GitHub repository allow list prefixes."},
+	{key: KeyGithubCloneDepth, defaultValue: 0, description: "Git clone depth to use for GitHub merge request checkouts. Zero means full history."},
+	{key: KeyGitlabCloneDepth, defaultValue: 0, description: "Git clone depth to use for GitLab merge request checkouts. Zero means full history."},
 }
 
 func init() {
@@ -102,6 +106,9 @@ func Reload() {
 	cfg := Config{}
 	err := viper.Unmarshal(&cfg, func(dc *mapstructure.DecoderConfig) {
 		dc.DecodeHook = mapstructure.ComposeDecodeHookFunc(
+			trimStringHook(),
+			trimStringSliceHook(),
+			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 		)
 	})
@@ -109,21 +116,33 @@ func Reload() {
 		panic(err)
 	}
 
-	cfg.LogLevel = strings.TrimSpace(cfg.LogLevel)
-	cfg.OTELCollectorHost = strings.TrimSpace(cfg.OTELCollectorHost)
-	cfg.OTELCollectorPort = strings.TrimSpace(cfg.OTELCollectorPort)
-	cfg.GitlabHookSecretKey = strings.TrimSpace(cfg.GitlabHookSecretKey)
-	cfg.GithubHookSecretKey = strings.TrimSpace(cfg.GithubHookSecretKey)
-	cfg.DefaultTFCOrganization = strings.TrimSpace(cfg.DefaultTFCOrganization)
-	cfg.NATSServiceURL = strings.TrimSpace(cfg.NATSServiceURL)
-
-	cfg.WorkspaceAllowList = trimAndFilter(cfg.WorkspaceAllowList)
-	cfg.WorkspaceDenyList = trimAndFilter(cfg.WorkspaceDenyList)
-	cfg.GitlabProjectAllowList = trimAndFilter(cfg.GitlabProjectAllowList)
-	cfg.LegacyProjectAllowList = trimAndFilter(cfg.LegacyProjectAllowList)
-	cfg.GithubRepoAllowList = trimAndFilter(cfg.GithubRepoAllowList)
-
 	C = cfg
+}
+
+func RegisterFlags(fs *pflag.FlagSet) error {
+	for _, item := range bindings {
+		switch def := item.defaultValue.(type) {
+		case string:
+			if item.shorthand != "" {
+				fs.StringP(item.key, item.shorthand, def, item.description)
+			} else {
+				fs.String(item.key, def, item.description)
+			}
+		case bool:
+			fs.Bool(item.key, def, item.description)
+		case int:
+			fs.Int(item.key, def, item.description)
+		case []string:
+			fs.StringSlice(item.key, def, item.description)
+		default:
+			continue
+		}
+		if err := viper.BindPFlag(item.key, fs.Lookup(item.key)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func trimAndFilter(items []string) []string {
@@ -138,4 +157,38 @@ func trimAndFilter(items []string) []string {
 		return nil
 	}
 	return result
+}
+
+func trimStringHook() mapstructure.DecodeHookFuncType {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if from.Kind() != reflect.String || to.Kind() != reflect.String {
+			return data, nil
+		}
+		return strings.TrimSpace(data.(string)), nil
+	}
+}
+
+func trimStringSliceHook() mapstructure.DecodeHookFuncType {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to != reflect.TypeOf([]string{}) {
+			return data, nil
+		}
+
+		switch value := data.(type) {
+		case string:
+			return trimAndFilter(strings.Split(value, ",")), nil
+		case []string:
+			return trimAndFilter(value), nil
+		case []any:
+			items := make([]string, 0, len(value))
+			for _, item := range value {
+				if str, ok := item.(string); ok {
+					items = append(items, str)
+				}
+			}
+			return trimAndFilter(items), nil
+		default:
+			return data, nil
+		}
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ func Init() {
 	Reload()
 }
 
-func Reload() {
+func Load() (Config, error) {
 	cfg := Config{}
 	err := viper.Unmarshal(&cfg, func(dc *mapstructure.DecoderConfig) {
 		dc.DecodeHook = mapstructure.ComposeDecodeHookFunc(
@@ -112,6 +112,11 @@ func Reload() {
 			mapstructure.StringToSliceHookFunc(","),
 		)
 	})
+	return cfg, err
+}
+
+func Reload() {
+	cfg, err := Load()
 	if err != nil {
 		panic(err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,12 +3,9 @@ package config
 import (
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 )
-
-func init() {
-	Init()
-}
 
 const (
 	KeyLogLevel                 = "log-level"
@@ -32,6 +29,30 @@ const (
 	KeyGitlabCloneDepth         = "gitlab-clone-depth"
 )
 
+type Config struct {
+	LogLevel                 string   `mapstructure:"log-level"`
+	DevMode                  bool     `mapstructure:"dev-mode"`
+	OTELEnabled              bool     `mapstructure:"otel-enabled"`
+	OTELCollectorHost        string   `mapstructure:"otel-collector-host"`
+	OTELCollectorPort        string   `mapstructure:"otel-collector-port"`
+	GitlabHookSecretKey      string   `mapstructure:"gitlab-hook-secret-key"`
+	GithubHookSecretKey      string   `mapstructure:"github-hook-secret-key"`
+	DefaultTFCOrganization   string   `mapstructure:"default-tfc-organization"`
+	WorkspaceAllowList       []string `mapstructure:"workspace-allow-list"`
+	WorkspaceDenyList        []string `mapstructure:"workspace-deny-list"`
+	AllowAutoMerge           bool     `mapstructure:"allow-auto-merge"`
+	FailCIOnSentinelSoftFail bool     `mapstructure:"fail-ci-on-sentinel-soft-fail"`
+	DeleteOldComments        bool     `mapstructure:"delete-old-comments"`
+	NATSServiceURL           string   `mapstructure:"nats-service-url"`
+	GitlabProjectAllowList   []string `mapstructure:"gitlab-project-allow-list"`
+	LegacyProjectAllowList   []string `mapstructure:"project-allow-list"`
+	GithubRepoAllowList      []string `mapstructure:"github-repo-allow-list"`
+	GithubCloneDepth         int      `mapstructure:"github-clone-depth"`
+	GitlabCloneDepth         int      `mapstructure:"gitlab-clone-depth"`
+}
+
+var C Config
+
 type binding struct {
 	key          string
 	defaultValue any
@@ -41,22 +62,26 @@ var bindings = []binding{
 	{key: KeyLogLevel, defaultValue: "info"},
 	{key: KeyDevMode, defaultValue: false},
 	{key: KeyOTELEnabled, defaultValue: false},
-	{key: KeyOTELCollectorHost},
-	{key: KeyOTELCollectorPort},
-	{key: KeyGitlabHookSecretKey},
-	{key: KeyGithubHookSecretKey},
-	{key: KeyDefaultTFCOrganization},
-	{key: KeyWorkspaceAllowList},
-	{key: KeyWorkspaceDenyList},
+	{key: KeyOTELCollectorHost, defaultValue: ""},
+	{key: KeyOTELCollectorPort, defaultValue: ""},
+	{key: KeyGitlabHookSecretKey, defaultValue: ""},
+	{key: KeyGithubHookSecretKey, defaultValue: ""},
+	{key: KeyDefaultTFCOrganization, defaultValue: ""},
+	{key: KeyWorkspaceAllowList, defaultValue: []string{}},
+	{key: KeyWorkspaceDenyList, defaultValue: []string{}},
 	{key: KeyAllowAutoMerge, defaultValue: true},
 	{key: KeyFailCIOnSentinelSoftFail, defaultValue: false},
 	{key: KeyDeleteOldComments, defaultValue: false},
-	{key: KeyNATSServiceURL},
-	{key: KeyGitlabProjectAllowList},
-	{key: KeyLegacyProjectAllowList},
-	{key: KeyGithubRepoAllowList},
-	{key: KeyGithubCloneDepth},
-	{key: KeyGitlabCloneDepth},
+	{key: KeyNATSServiceURL, defaultValue: ""},
+	{key: KeyGitlabProjectAllowList, defaultValue: []string{}},
+	{key: KeyLegacyProjectAllowList, defaultValue: []string{}},
+	{key: KeyGithubRepoAllowList, defaultValue: []string{}},
+	{key: KeyGithubCloneDepth, defaultValue: 0},
+	{key: KeyGitlabCloneDepth, defaultValue: 0},
+}
+
+func init() {
+	Init()
 }
 
 func Init() {
@@ -69,121 +94,36 @@ func Init() {
 			viper.SetDefault(item.key, item.defaultValue)
 		}
 	}
+
+	Reload()
 }
 
-func String(key string) string {
-	return strings.TrimSpace(viper.GetString(key))
-}
-
-func Bool(key string) bool {
-	return viper.GetBool(key)
-}
-
-func Int(key string) int {
-	return viper.GetInt(key)
-}
-
-func StringList(key string) []string {
-	raw := viper.Get(key)
-	switch value := raw.(type) {
-	case []string:
-		return trimAndFilter(value)
-	case []any:
-		items := make([]string, 0, len(value))
-		for _, item := range value {
-			if str, ok := item.(string); ok {
-				items = append(items, str)
-			}
-		}
-		return trimAndFilter(items)
-	case string:
-		return splitCSV(value)
-	default:
-		return splitCSV(viper.GetString(key))
+func Reload() {
+	cfg := Config{}
+	err := viper.Unmarshal(&cfg, func(dc *mapstructure.DecoderConfig) {
+		dc.DecodeHook = mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToSliceHookFunc(","),
+		)
+	})
+	if err != nil {
+		panic(err)
 	}
-}
 
-func LogLevel() string {
-	return String(KeyLogLevel)
-}
+	cfg.LogLevel = strings.TrimSpace(cfg.LogLevel)
+	cfg.OTELCollectorHost = strings.TrimSpace(cfg.OTELCollectorHost)
+	cfg.OTELCollectorPort = strings.TrimSpace(cfg.OTELCollectorPort)
+	cfg.GitlabHookSecretKey = strings.TrimSpace(cfg.GitlabHookSecretKey)
+	cfg.GithubHookSecretKey = strings.TrimSpace(cfg.GithubHookSecretKey)
+	cfg.DefaultTFCOrganization = strings.TrimSpace(cfg.DefaultTFCOrganization)
+	cfg.NATSServiceURL = strings.TrimSpace(cfg.NATSServiceURL)
 
-func DevModeEnabled() bool {
-	return Bool(KeyDevMode)
-}
+	cfg.WorkspaceAllowList = trimAndFilter(cfg.WorkspaceAllowList)
+	cfg.WorkspaceDenyList = trimAndFilter(cfg.WorkspaceDenyList)
+	cfg.GitlabProjectAllowList = trimAndFilter(cfg.GitlabProjectAllowList)
+	cfg.LegacyProjectAllowList = trimAndFilter(cfg.LegacyProjectAllowList)
+	cfg.GithubRepoAllowList = trimAndFilter(cfg.GithubRepoAllowList)
 
-func OTELEnabled() bool {
-	return Bool(KeyOTELEnabled)
-}
-
-func OTELCollectorHost() string {
-	return String(KeyOTELCollectorHost)
-}
-
-func OTELCollectorPort() string {
-	return String(KeyOTELCollectorPort)
-}
-
-func GitlabHookSecretKey() string {
-	return String(KeyGitlabHookSecretKey)
-}
-
-func GithubHookSecretKey() string {
-	return String(KeyGithubHookSecretKey)
-}
-
-func DefaultTFCOrganization() string {
-	return String(KeyDefaultTFCOrganization)
-}
-
-func WorkspaceAllowList() []string {
-	return StringList(KeyWorkspaceAllowList)
-}
-
-func WorkspaceDenyList() []string {
-	return StringList(KeyWorkspaceDenyList)
-}
-
-func AutoMergeEnabled() bool {
-	return Bool(KeyAllowAutoMerge)
-}
-
-func FailCIOnSentinelSoftFail() bool {
-	return Bool(KeyFailCIOnSentinelSoftFail)
-}
-
-func DeleteOldCommentsEnabled() bool {
-	return Bool(KeyDeleteOldComments)
-}
-
-func NATSServiceURL() string {
-	return String(KeyNATSServiceURL)
-}
-
-func GitlabProjectAllowList() []string {
-	return StringList(KeyGitlabProjectAllowList)
-}
-
-func LegacyProjectAllowList() []string {
-	return StringList(KeyLegacyProjectAllowList)
-}
-
-func GithubRepoAllowList() []string {
-	return StringList(KeyGithubRepoAllowList)
-}
-
-func GithubCloneDepth() int {
-	return Int(KeyGithubCloneDepth)
-}
-
-func GitlabCloneDepth() int {
-	return Int(KeyGitlabCloneDepth)
-}
-
-func splitCSV(value string) []string {
-	if strings.TrimSpace(value) == "" {
-		return nil
-	}
-	return trimAndFilter(strings.Split(value, ","))
+	C = cfg
 }
 
 func trimAndFilter(items []string) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,35 +34,37 @@ const (
 
 type binding struct {
 	key          string
-	env          string
 	defaultValue any
 }
 
 var bindings = []binding{
-	{key: KeyLogLevel, env: "TFBUDDY_LOG_LEVEL", defaultValue: "info"},
-	{key: KeyDevMode, env: "TFBUDDY_DEV_MODE", defaultValue: false},
-	{key: KeyOTELEnabled, env: "TFBUDDY_OTEL_ENABLED", defaultValue: false},
-	{key: KeyOTELCollectorHost, env: "TFBUDDY_OTEL_COLLECTOR_HOST"},
-	{key: KeyOTELCollectorPort, env: "TFBUDDY_OTEL_COLLECTOR_PORT"},
-	{key: KeyGitlabHookSecretKey, env: "TFBUDDY_GITLAB_HOOK_SECRET_KEY"},
-	{key: KeyGithubHookSecretKey, env: "TFBUDDY_GITHUB_HOOK_SECRET_KEY"},
-	{key: KeyDefaultTFCOrganization, env: "TFBUDDY_DEFAULT_TFC_ORGANIZATION"},
-	{key: KeyWorkspaceAllowList, env: "TFBUDDY_WORKSPACE_ALLOW_LIST"},
-	{key: KeyWorkspaceDenyList, env: "TFBUDDY_WORKSPACE_DENY_LIST"},
-	{key: KeyAllowAutoMerge, env: "TFBUDDY_ALLOW_AUTO_MERGE", defaultValue: true},
-	{key: KeyFailCIOnSentinelSoftFail, env: "TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL", defaultValue: false},
-	{key: KeyDeleteOldComments, env: "TFBUDDY_DELETE_OLD_COMMENTS", defaultValue: false},
-	{key: KeyNATSServiceURL, env: "TFBUDDY_NATS_SERVICE_URL"},
-	{key: KeyGitlabProjectAllowList, env: "TFBUDDY_GITLAB_PROJECT_ALLOW_LIST"},
-	{key: KeyLegacyProjectAllowList, env: "TFBUDDY_PROJECT_ALLOW_LIST"},
-	{key: KeyGithubRepoAllowList, env: "TFBUDDY_GITHUB_REPO_ALLOW_LIST"},
-	{key: KeyGithubCloneDepth, env: "TFBUDDY_GITHUB_CLONE_DEPTH"},
-	{key: KeyGitlabCloneDepth, env: "TFBUDDY_GITLAB_CLONE_DEPTH"},
+	{key: KeyLogLevel, defaultValue: "info"},
+	{key: KeyDevMode, defaultValue: false},
+	{key: KeyOTELEnabled, defaultValue: false},
+	{key: KeyOTELCollectorHost},
+	{key: KeyOTELCollectorPort},
+	{key: KeyGitlabHookSecretKey},
+	{key: KeyGithubHookSecretKey},
+	{key: KeyDefaultTFCOrganization},
+	{key: KeyWorkspaceAllowList},
+	{key: KeyWorkspaceDenyList},
+	{key: KeyAllowAutoMerge, defaultValue: true},
+	{key: KeyFailCIOnSentinelSoftFail, defaultValue: false},
+	{key: KeyDeleteOldComments, defaultValue: false},
+	{key: KeyNATSServiceURL},
+	{key: KeyGitlabProjectAllowList},
+	{key: KeyLegacyProjectAllowList},
+	{key: KeyGithubRepoAllowList},
+	{key: KeyGithubCloneDepth},
+	{key: KeyGitlabCloneDepth},
 }
 
 func Init() {
+	viper.SetEnvPrefix("TFBUDDY")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+
 	for _, item := range bindings {
-		_ = viper.BindEnv(item.key, item.env)
 		if item.defaultValue != nil {
 			viper.SetDefault(item.key, item.defaultValue)
 		}
@@ -175,11 +177,6 @@ func GithubCloneDepth() int {
 
 func GitlabCloneDepth() int {
 	return Int(KeyGitlabCloneDepth)
-}
-
-func StringListForUnknownEnv(envName string) []string {
-	_ = viper.BindEnv(envName, envName)
-	return StringList(envName)
 }
 
 func splitCSV(value string) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+func init() {
+	Init()
+}
+
+const (
+	KeyLogLevel                 = "log-level"
+	KeyDevMode                  = "dev-mode"
+	KeyOTELEnabled              = "otel-enabled"
+	KeyOTELCollectorHost        = "otel-collector-host"
+	KeyOTELCollectorPort        = "otel-collector-port"
+	KeyGitlabHookSecretKey      = "gitlab-hook-secret-key"
+	KeyGithubHookSecretKey      = "github-hook-secret-key"
+	KeyDefaultTFCOrganization   = "default-tfc-organization"
+	KeyWorkspaceAllowList       = "workspace-allow-list"
+	KeyWorkspaceDenyList        = "workspace-deny-list"
+	KeyAllowAutoMerge           = "allow-auto-merge"
+	KeyFailCIOnSentinelSoftFail = "fail-ci-on-sentinel-soft-fail"
+	KeyDeleteOldComments        = "delete-old-comments"
+	KeyNATSServiceURL           = "nats-service-url"
+	KeyGitlabProjectAllowList   = "gitlab-project-allow-list"
+	KeyLegacyProjectAllowList   = "project-allow-list"
+	KeyGithubRepoAllowList      = "github-repo-allow-list"
+	KeyGithubCloneDepth         = "github-clone-depth"
+	KeyGitlabCloneDepth         = "gitlab-clone-depth"
+)
+
+type binding struct {
+	key          string
+	env          string
+	defaultValue any
+}
+
+var bindings = []binding{
+	{key: KeyLogLevel, env: "TFBUDDY_LOG_LEVEL", defaultValue: "info"},
+	{key: KeyDevMode, env: "TFBUDDY_DEV_MODE", defaultValue: false},
+	{key: KeyOTELEnabled, env: "TFBUDDY_OTEL_ENABLED", defaultValue: false},
+	{key: KeyOTELCollectorHost, env: "TFBUDDY_OTEL_COLLECTOR_HOST"},
+	{key: KeyOTELCollectorPort, env: "TFBUDDY_OTEL_COLLECTOR_PORT"},
+	{key: KeyGitlabHookSecretKey, env: "TFBUDDY_GITLAB_HOOK_SECRET_KEY"},
+	{key: KeyGithubHookSecretKey, env: "TFBUDDY_GITHUB_HOOK_SECRET_KEY"},
+	{key: KeyDefaultTFCOrganization, env: "TFBUDDY_DEFAULT_TFC_ORGANIZATION"},
+	{key: KeyWorkspaceAllowList, env: "TFBUDDY_WORKSPACE_ALLOW_LIST"},
+	{key: KeyWorkspaceDenyList, env: "TFBUDDY_WORKSPACE_DENY_LIST"},
+	{key: KeyAllowAutoMerge, env: "TFBUDDY_ALLOW_AUTO_MERGE", defaultValue: true},
+	{key: KeyFailCIOnSentinelSoftFail, env: "TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL", defaultValue: false},
+	{key: KeyDeleteOldComments, env: "TFBUDDY_DELETE_OLD_COMMENTS", defaultValue: false},
+	{key: KeyNATSServiceURL, env: "TFBUDDY_NATS_SERVICE_URL"},
+	{key: KeyGitlabProjectAllowList, env: "TFBUDDY_GITLAB_PROJECT_ALLOW_LIST"},
+	{key: KeyLegacyProjectAllowList, env: "TFBUDDY_PROJECT_ALLOW_LIST"},
+	{key: KeyGithubRepoAllowList, env: "TFBUDDY_GITHUB_REPO_ALLOW_LIST"},
+	{key: KeyGithubCloneDepth, env: "TFBUDDY_GITHUB_CLONE_DEPTH"},
+	{key: KeyGitlabCloneDepth, env: "TFBUDDY_GITLAB_CLONE_DEPTH"},
+}
+
+func Init() {
+	for _, item := range bindings {
+		_ = viper.BindEnv(item.key, item.env)
+		if item.defaultValue != nil {
+			viper.SetDefault(item.key, item.defaultValue)
+		}
+	}
+}
+
+func String(key string) string {
+	return strings.TrimSpace(viper.GetString(key))
+}
+
+func Bool(key string) bool {
+	return viper.GetBool(key)
+}
+
+func Int(key string) int {
+	return viper.GetInt(key)
+}
+
+func StringList(key string) []string {
+	raw := viper.Get(key)
+	switch value := raw.(type) {
+	case []string:
+		return trimAndFilter(value)
+	case []any:
+		items := make([]string, 0, len(value))
+		for _, item := range value {
+			if str, ok := item.(string); ok {
+				items = append(items, str)
+			}
+		}
+		return trimAndFilter(items)
+	case string:
+		return splitCSV(value)
+	default:
+		return splitCSV(viper.GetString(key))
+	}
+}
+
+func LogLevel() string {
+	return String(KeyLogLevel)
+}
+
+func DevModeEnabled() bool {
+	return Bool(KeyDevMode)
+}
+
+func OTELEnabled() bool {
+	return Bool(KeyOTELEnabled)
+}
+
+func OTELCollectorHost() string {
+	return String(KeyOTELCollectorHost)
+}
+
+func OTELCollectorPort() string {
+	return String(KeyOTELCollectorPort)
+}
+
+func GitlabHookSecretKey() string {
+	return String(KeyGitlabHookSecretKey)
+}
+
+func GithubHookSecretKey() string {
+	return String(KeyGithubHookSecretKey)
+}
+
+func DefaultTFCOrganization() string {
+	return String(KeyDefaultTFCOrganization)
+}
+
+func WorkspaceAllowList() []string {
+	return StringList(KeyWorkspaceAllowList)
+}
+
+func WorkspaceDenyList() []string {
+	return StringList(KeyWorkspaceDenyList)
+}
+
+func AutoMergeEnabled() bool {
+	return Bool(KeyAllowAutoMerge)
+}
+
+func FailCIOnSentinelSoftFail() bool {
+	return Bool(KeyFailCIOnSentinelSoftFail)
+}
+
+func DeleteOldCommentsEnabled() bool {
+	return Bool(KeyDeleteOldComments)
+}
+
+func NATSServiceURL() string {
+	return String(KeyNATSServiceURL)
+}
+
+func GitlabProjectAllowList() []string {
+	return StringList(KeyGitlabProjectAllowList)
+}
+
+func LegacyProjectAllowList() []string {
+	return StringList(KeyLegacyProjectAllowList)
+}
+
+func GithubRepoAllowList() []string {
+	return StringList(KeyGithubRepoAllowList)
+}
+
+func GithubCloneDepth() int {
+	return Int(KeyGithubCloneDepth)
+}
+
+func GitlabCloneDepth() int {
+	return Int(KeyGitlabCloneDepth)
+}
+
+func StringListForUnknownEnv(envName string) []string {
+	_ = viper.BindEnv(envName, envName)
+	return StringList(envName)
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return trimAndFilter(strings.Split(value, ","))
+}
+
+func trimAndFilter(items []string) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		trimmed := strings.TrimSpace(item)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,10 +17,10 @@ func TestStringListParsesCommaSeparatedEnv(t *testing.T) {
 	t.Setenv("TFBUDDY_WORKSPACE_ALLOW_LIST", " org-a/ws-a,ws-b,, org-c/ws-c ")
 	resetViperForTest(t)
 
-	got := StringList(KeyWorkspaceAllowList)
+	got := C.WorkspaceAllowList
 	want := []string{"org-a/ws-a", "ws-b", "org-c/ws-c"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("StringList(%q) = %v, want %v", KeyWorkspaceAllowList, got, want)
+		t.Fatalf("C.WorkspaceAllowList = %v, want %v", got, want)
 	}
 }
 
@@ -28,24 +28,24 @@ func TestStringListReturnsNilForEmptyValues(t *testing.T) {
 	t.Setenv("TFBUDDY_WORKSPACE_DENY_LIST", " , , ")
 	resetViperForTest(t)
 
-	if got := StringList(KeyWorkspaceDenyList); got != nil {
-		t.Fatalf("StringList(%q) = %v, want nil", KeyWorkspaceDenyList, got)
+	if got := C.WorkspaceDenyList; got != nil {
+		t.Fatalf("C.WorkspaceDenyList = %v, want nil", got)
 	}
 }
 
 func TestAutoMergeDefaultsToTrue(t *testing.T) {
 	resetViperForTest(t)
 
-	if !AutoMergeEnabled() {
-		t.Fatal("AutoMergeEnabled() = false, want true")
+	if !C.AllowAutoMerge {
+		t.Fatal("C.AllowAutoMerge = false, want true")
 	}
 }
 
 func TestDeleteOldCommentsDefaultsToFalse(t *testing.T) {
 	resetViperForTest(t)
 
-	if DeleteOldCommentsEnabled() {
-		t.Fatal("DeleteOldCommentsEnabled() = true, want false")
+	if C.DeleteOldComments {
+		t.Fatal("C.DeleteOldComments = true, want false")
 	}
 }
 
@@ -53,24 +53,24 @@ func TestDeleteOldCommentsCanBeEnabledFromEnv(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
 	resetViperForTest(t)
 
-	if !DeleteOldCommentsEnabled() {
-		t.Fatal("DeleteOldCommentsEnabled() = false, want true")
+	if !C.DeleteOldComments {
+		t.Fatal("C.DeleteOldComments = false, want true")
 	}
 }
 
 func TestSentinelSoftFailDefaultsToFalse(t *testing.T) {
 	resetViperForTest(t)
 
-	if FailCIOnSentinelSoftFail() {
-		t.Fatal("FailCIOnSentinelSoftFail() = true, want false")
+	if C.FailCIOnSentinelSoftFail {
+		t.Fatal("C.FailCIOnSentinelSoftFail = true, want false")
 	}
 }
 
 func TestDevModeDefaultsToFalse(t *testing.T) {
 	resetViperForTest(t)
 
-	if DevModeEnabled() {
-		t.Fatal("DevModeEnabled() = true, want false")
+	if C.DevMode {
+		t.Fatal("C.DevMode = true, want false")
 	}
 }
 
@@ -80,13 +80,13 @@ func TestStringAccessorsReadConfiguredValues(t *testing.T) {
 	t.Setenv("TFBUDDY_DEFAULT_TFC_ORGANIZATION", "zapier")
 	resetViperForTest(t)
 
-	if got := LogLevel(); got != "debug" {
-		t.Fatalf("LogLevel() = %q, want %q", got, "debug")
+	if got := C.LogLevel; got != "debug" {
+		t.Fatalf("C.LogLevel = %q, want %q", got, "debug")
 	}
-	if got := NATSServiceURL(); got != "nats://example:4222" {
-		t.Fatalf("NATSServiceURL() = %q, want %q", got, "nats://example:4222")
+	if got := C.NATSServiceURL; got != "nats://example:4222" {
+		t.Fatalf("C.NATSServiceURL = %q, want %q", got, "nats://example:4222")
 	}
-	if got := DefaultTFCOrganization(); got != "zapier" {
-		t.Fatalf("DefaultTFCOrganization() = %q, want %q", got, "zapier")
+	if got := C.DefaultTFCOrganization; got != "zapier" {
+		t.Fatalf("C.DefaultTFCOrganization = %q, want %q", got, "zapier")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func resetViperForTest(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	Init()
+}
+
+func TestStringListParsesCommaSeparatedEnv(t *testing.T) {
+	t.Setenv("TFBUDDY_WORKSPACE_ALLOW_LIST", " org-a/ws-a,ws-b,, org-c/ws-c ")
+	resetViperForTest(t)
+
+	got := StringList(KeyWorkspaceAllowList)
+	want := []string{"org-a/ws-a", "ws-b", "org-c/ws-c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("StringList(%q) = %v, want %v", KeyWorkspaceAllowList, got, want)
+	}
+}
+
+func TestStringListReturnsNilForEmptyValues(t *testing.T) {
+	t.Setenv("TFBUDDY_WORKSPACE_DENY_LIST", " , , ")
+	resetViperForTest(t)
+
+	if got := StringList(KeyWorkspaceDenyList); got != nil {
+		t.Fatalf("StringList(%q) = %v, want nil", KeyWorkspaceDenyList, got)
+	}
+}
+
+func TestAutoMergeDefaultsToTrue(t *testing.T) {
+	resetViperForTest(t)
+
+	if !AutoMergeEnabled() {
+		t.Fatal("AutoMergeEnabled() = false, want true")
+	}
+}
+
+func TestDeleteOldCommentsDefaultsToFalse(t *testing.T) {
+	resetViperForTest(t)
+
+	if DeleteOldCommentsEnabled() {
+		t.Fatal("DeleteOldCommentsEnabled() = true, want false")
+	}
+}
+
+func TestDeleteOldCommentsCanBeEnabledFromEnv(t *testing.T) {
+	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	resetViperForTest(t)
+
+	if !DeleteOldCommentsEnabled() {
+		t.Fatal("DeleteOldCommentsEnabled() = false, want true")
+	}
+}
+
+func TestSentinelSoftFailDefaultsToFalse(t *testing.T) {
+	resetViperForTest(t)
+
+	if FailCIOnSentinelSoftFail() {
+		t.Fatal("FailCIOnSentinelSoftFail() = true, want false")
+	}
+}
+
+func TestDevModeDefaultsToFalse(t *testing.T) {
+	resetViperForTest(t)
+
+	if DevModeEnabled() {
+		t.Fatal("DevModeEnabled() = true, want false")
+	}
+}
+
+func TestStringAccessorsReadConfiguredValues(t *testing.T) {
+	t.Setenv("TFBUDDY_LOG_LEVEL", "debug")
+	t.Setenv("TFBUDDY_NATS_SERVICE_URL", "nats://example:4222")
+	t.Setenv("TFBUDDY_DEFAULT_TFC_ORGANIZATION", "zapier")
+	resetViperForTest(t)
+
+	if got := LogLevel(); got != "debug" {
+		t.Fatalf("LogLevel() = %q, want %q", got, "debug")
+	}
+	if got := NATSServiceURL(); got != "nats://example:4222" {
+		t.Fatalf("NATSServiceURL() = %q, want %q", got, "nats://example:4222")
+	}
+	if got := DefaultTFCOrganization(); got != "zapier" {
+		t.Fatalf("DefaultTFCOrganization() = %q, want %q", got, "zapier")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -11,6 +12,10 @@ func resetViperForTest(t *testing.T) {
 	t.Helper()
 	viper.Reset()
 	Init()
+	fs := pflag.NewFlagSet("config-test", pflag.ContinueOnError)
+	if err := RegisterFlags(fs); err != nil {
+		t.Fatalf("RegisterFlags() error = %v", err)
+	}
 }
 
 func TestStringListParsesCommaSeparatedEnv(t *testing.T) {
@@ -88,5 +93,35 @@ func TestStringAccessorsReadConfiguredValues(t *testing.T) {
 	}
 	if got := C.DefaultTFCOrganization; got != "zapier" {
 		t.Fatalf("C.DefaultTFCOrganization = %q, want %q", got, "zapier")
+	}
+}
+
+func TestRegisterFlagsBindsParsedValuesIntoConfigStruct(t *testing.T) {
+	viper.Reset()
+	Init()
+
+	fs := pflag.NewFlagSet("config-test", pflag.ContinueOnError)
+	if err := RegisterFlags(fs); err != nil {
+		t.Fatalf("RegisterFlags() error = %v", err)
+	}
+	if err := fs.Parse([]string{
+		"--log-level=trace",
+		"--delete-old-comments=true",
+		"--workspace-allow-list=org-a/ws-a,org-b/ws-b",
+	}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	Reload()
+
+	if got := C.LogLevel; got != "trace" {
+		t.Fatalf("C.LogLevel = %q, want %q", got, "trace")
+	}
+	if !C.DeleteOldComments {
+		t.Fatal("C.DeleteOldComments = false, want true")
+	}
+	wantAllowList := []string{"org-a/ws-a", "org-b/ws-b"}
+	if !reflect.DeepEqual(C.WorkspaceAllowList, wantAllowList) {
+		t.Fatalf("C.WorkspaceAllowList = %v, want %v", C.WorkspaceAllowList, wantAllowList)
 	}
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/zapier/tfbuddy/internal/config"
 )
 
 const (
@@ -24,9 +23,9 @@ const (
 	colorDarkGray = 90
 )
 
-func SetupLogOutput(level zerolog.Level) {
+func SetupLogOutput(devMode bool, level zerolog.Level) {
 	// Setup Human friendly Console Output for dev mode
-	if config.C.DevMode {
+	if devMode {
 		output := zerolog.ConsoleWriter{Out: os.Stdout}
 		output.FormatLevel = formatLevel(false)
 		output.FormatMessage = func(i interface{}) string {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -26,7 +26,7 @@ const (
 
 func SetupLogOutput(level zerolog.Level) {
 	// Setup Human friendly Console Output for dev mode
-	if config.DevModeEnabled() {
+	if config.C.DevMode {
 		output := zerolog.ConsoleWriter{Out: os.Stdout}
 		output.FormatLevel = formatLevel(false)
 		output.FormatMessage = func(i interface{}) string {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 const (
@@ -25,8 +26,7 @@ const (
 
 func SetupLogOutput(level zerolog.Level) {
 	// Setup Human friendly Console Output for dev mode
-	devMode := os.Getenv("TFBUDDY_DEV_MODE")
-	if devMode != "" {
+	if config.DevModeEnabled() {
 		output := zerolog.ConsoleWriter{Out: os.Stdout}
 		output.FormatLevel = formatLevel(false)
 		output.FormatMessage = func(i interface{}) string {

--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -9,11 +9,11 @@ func getAllowList(envVar string) []string {
 	var allowed []string
 	switch envVar {
 	case githubRepoAllowListEnv:
-		allowed = config.GithubRepoAllowList()
+		allowed = config.C.GithubRepoAllowList
 	case GitlabProjectAllowListEnv:
-		allowed = config.GitlabProjectAllowList()
+		allowed = config.C.GitlabProjectAllowList
 	case legacyAllowListEnv:
-		allowed = config.LegacyProjectAllowList()
+		allowed = config.C.LegacyProjectAllowList
 	default:
 		return nil
 	}

--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -15,7 +15,7 @@ func getAllowList(envVar string) []string {
 	case legacyAllowListEnv:
 		allowed = config.LegacyProjectAllowList()
 	default:
-		allowed = config.StringListForUnknownEnv(envVar)
+		return nil
 	}
 
 	if len(allowed) > 0 {

--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -1,24 +1,28 @@
 package allow_list
 
 import (
-	"os"
-	"strings"
-
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func getAllowList(envVar string) []string {
-	allowed := strings.TrimSpace(os.Getenv(envVar))
+	var allowed []string
+	switch envVar {
+	case githubRepoAllowListEnv:
+		allowed = config.GithubRepoAllowList()
+	case GitlabProjectAllowListEnv:
+		allowed = config.GitlabProjectAllowList()
+	case legacyAllowListEnv:
+		allowed = config.LegacyProjectAllowList()
+	default:
+		allowed = config.StringListForUnknownEnv(envVar)
+	}
 
-	if allowed != "" {
-		allowedParts := strings.Split(allowed, ",")
-		allowList := make([]string, 0)
-		for _, p := range allowedParts {
-			prefix := strings.TrimSpace(p)
-			if prefix != "" {
-				log.Info().Str("prefix", prefix).Msg("adding repo prefix to allow list")
-				allowList = append(allowList, prefix)
-			}
+	if len(allowed) > 0 {
+		allowList := make([]string, 0, len(allowed))
+		for _, prefix := range allowed {
+			log.Info().Str("prefix", prefix).Msg("adding repo prefix to allow list")
+			allowList = append(allowList, prefix)
 		}
 		if len(allowList) == 0 {
 			return nil

--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -5,15 +5,15 @@ import (
 	"github.com/zapier/tfbuddy/internal/config"
 )
 
-func getAllowList(envVar string) []string {
+func getAllowList(cfg config.Config, envVar string) []string {
 	var allowed []string
 	switch envVar {
 	case githubRepoAllowListEnv:
-		allowed = config.C.GithubRepoAllowList
+		allowed = cfg.GithubRepoAllowList
 	case GitlabProjectAllowListEnv:
-		allowed = config.C.GitlabProjectAllowList
+		allowed = cfg.GitlabProjectAllowList
 	case legacyAllowListEnv:
-		allowed = config.C.LegacyProjectAllowList
+		allowed = cfg.LegacyProjectAllowList
 	default:
 		return nil
 	}

--- a/pkg/allow_list/common.go
+++ b/pkg/allow_list/common.go
@@ -1,26 +1,19 @@
 package allow_list
 
 import (
+	"strings"
+
 	"github.com/rs/zerolog/log"
-	"github.com/zapier/tfbuddy/internal/config"
 )
 
-func getAllowList(cfg config.Config, envVar string) []string {
-	var allowed []string
-	switch envVar {
-	case githubRepoAllowListEnv:
-		allowed = cfg.GithubRepoAllowList
-	case GitlabProjectAllowListEnv:
-		allowed = cfg.GitlabProjectAllowList
-	case legacyAllowListEnv:
-		allowed = cfg.LegacyProjectAllowList
-	default:
-		return nil
-	}
-
+func getAllowList(allowed []string) []string {
 	if len(allowed) > 0 {
 		allowList := make([]string, 0, len(allowed))
 		for _, prefix := range allowed {
+			prefix = strings.TrimSpace(prefix)
+			if prefix == "" {
+				continue
+			}
 			log.Info().Str("prefix", prefix).Msg("adding repo prefix to allow list")
 			allowList = append(allowList, prefix)
 		}

--- a/pkg/allow_list/common_test.go
+++ b/pkg/allow_list/common_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetAllowList(t *testing.T) {
-	const testEnvVar = "TEST_ALLOW_LIST_ENV"
+	const testEnvVar = githubRepoAllowListEnv
 
 	tests := []struct {
 		name   string

--- a/pkg/allow_list/common_test.go
+++ b/pkg/allow_list/common_test.go
@@ -82,7 +82,7 @@ func TestGetAllowList(t *testing.T) {
 			t.Setenv(testEnvVar, tt.envVal)
 			config.Reload()
 
-			if got := getAllowList(testEnvVar); !reflect.DeepEqual(got, tt.want) {
+			if got := getAllowList(config.C, testEnvVar); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getAllowList() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/allow_list/common_test.go
+++ b/pkg/allow_list/common_test.go
@@ -3,86 +3,79 @@ package allow_list
 import (
 	"reflect"
 	"testing"
-
-	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func TestGetAllowList(t *testing.T) {
-	const testEnvVar = githubRepoAllowListEnv
-
 	tests := []struct {
-		name   string
-		envVal string
-		want   []string
+		name  string
+		input []string
+		want  []string
 	}{
 		{
-			name:   "multiple values",
-			envVal: "prefix1,prefix2,prefix3",
-			want:   []string{"prefix1", "prefix2", "prefix3"},
+			name:  "multiple values",
+			input: []string{"prefix1", "prefix2", "prefix3"},
+			want:  []string{"prefix1", "prefix2", "prefix3"},
 		},
 		{
-			name:   "single value",
-			envVal: "prefix1",
-			want:   []string{"prefix1"},
+			name:  "single value",
+			input: []string{"prefix1"},
+			want:  []string{"prefix1"},
 		},
 		{
-			name:   "values with spaces",
-			envVal: " prefix1 , prefix2 , prefix3 ",
-			want:   []string{"prefix1", "prefix2", "prefix3"},
+			name:  "values with spaces",
+			input: []string{" prefix1 ", " prefix2 ", " prefix3 "},
+			want:  []string{"prefix1", "prefix2", "prefix3"},
 		},
 		{
-			name:   "empty env",
-			envVal: "",
-			want:   nil,
+			name:  "empty env",
+			input: nil,
+			want:  nil,
 		},
 		{
-			name:   "only spaces",
-			envVal: "   ",
-			want:   nil,
+			name:  "only spaces",
+			input: []string{"   "},
+			want:  nil,
 		},
 		{
-			name:   "empty strings in list",
-			envVal: "prefix1,,prefix3",
-			want:   []string{"prefix1", "prefix3"},
+			name:  "empty strings in list",
+			input: []string{"prefix1", "", "prefix3"},
+			want:  []string{"prefix1", "prefix3"},
 		},
 		{
-			name:   "trailing comma",
-			envVal: "prefix1,prefix2,",
-			want:   []string{"prefix1", "prefix2"},
+			name:  "trailing comma",
+			input: []string{"prefix1", "prefix2", ""},
+			want:  []string{"prefix1", "prefix2"},
 		},
 		{
-			name:   "leading comma",
-			envVal: ",prefix1,prefix2",
-			want:   []string{"prefix1", "prefix2"},
+			name:  "leading comma",
+			input: []string{"", "prefix1", "prefix2"},
+			want:  []string{"prefix1", "prefix2"},
 		},
 		{
-			name:   "multiple consecutive commas",
-			envVal: "prefix1,,,prefix2",
-			want:   []string{"prefix1", "prefix2"},
+			name:  "multiple consecutive commas",
+			input: []string{"prefix1", "", "", "prefix2"},
+			want:  []string{"prefix1", "prefix2"},
 		},
 		{
-			name:   "only commas",
-			envVal: ",,,",
-			want:   nil,
+			name:  "only commas",
+			input: []string{"", "", "", ""},
+			want:  nil,
 		},
 		{
-			name:   "values with forward slashes",
-			envVal: "zapier/,github/org,gitlab/project",
-			want:   []string{"zapier/", "github/org", "gitlab/project"},
+			name:  "values with forward slashes",
+			input: []string{"zapier/", "github/org", "gitlab/project"},
+			want:  []string{"zapier/", "github/org", "gitlab/project"},
 		},
 		{
-			name:   "values with special characters",
-			envVal: "org-name,project_name,repo.name,user@domain",
-			want:   []string{"org-name", "project_name", "repo.name", "user@domain"},
+			name:  "values with special characters",
+			input: []string{"org-name", "project_name", "repo.name", "user@domain"},
+			want:  []string{"org-name", "project_name", "repo.name", "user@domain"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(testEnvVar, tt.envVal)
-			config.Reload()
-
-			if got := getAllowList(config.C, testEnvVar); !reflect.DeepEqual(got, tt.want) {
+			if got := getAllowList(tt.input); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getAllowList() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/allow_list/common_test.go
+++ b/pkg/allow_list/common_test.go
@@ -3,6 +3,8 @@ package allow_list
 import (
 	"reflect"
 	"testing"
+
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func TestGetAllowList(t *testing.T) {
@@ -78,6 +80,7 @@ func TestGetAllowList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(testEnvVar, tt.envVal)
+			config.Reload()
 
 			if got := getAllowList(testEnvVar); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getAllowList() = %v, want %v", got, tt.want)

--- a/pkg/allow_list/github.go
+++ b/pkg/allow_list/github.go
@@ -4,12 +4,13 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 const githubRepoAllowListEnv = "TFBUDDY_GITHUB_REPO_ALLOW_LIST"
 
-func IsGithubRepoAllowed(fullName string) bool {
-	githubAllowList := getAllowList(githubRepoAllowListEnv)
+func IsGithubRepoAllowed(cfg config.Config, fullName string) bool {
+	githubAllowList := getAllowList(cfg, githubRepoAllowListEnv)
 	if len(githubAllowList) == 0 {
 		log.Warn().Str("repo", fullName).Msg("denying action for repo because allow list is not set.")
 		return false

--- a/pkg/allow_list/github.go
+++ b/pkg/allow_list/github.go
@@ -7,10 +7,8 @@ import (
 	"github.com/zapier/tfbuddy/internal/config"
 )
 
-const githubRepoAllowListEnv = "TFBUDDY_GITHUB_REPO_ALLOW_LIST"
-
 func IsGithubRepoAllowed(cfg config.Config, fullName string) bool {
-	githubAllowList := getAllowList(cfg, githubRepoAllowListEnv)
+	githubAllowList := getAllowList(cfg.GithubRepoAllowList)
 	if len(githubAllowList) == 0 {
 		log.Warn().Str("repo", fullName).Msg("denying action for repo because allow list is not set.")
 		return false

--- a/pkg/allow_list/github_test.go
+++ b/pkg/allow_list/github_test.go
@@ -108,7 +108,7 @@ func TestIsGithubRepoAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(githubRepoAllowListEnv, tt.args.allowEnv)
+			t.Setenv("TFBUDDY_GITHUB_REPO_ALLOW_LIST", tt.args.allowEnv)
 			config.Reload()
 
 			if got := IsGithubRepoAllowed(config.C, tt.args.fullName); got != tt.want {

--- a/pkg/allow_list/github_test.go
+++ b/pkg/allow_list/github_test.go
@@ -2,6 +2,8 @@ package allow_list
 
 import (
 	"testing"
+
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func TestIsGithubRepoAllowed(t *testing.T) {
@@ -107,6 +109,7 @@ func TestIsGithubRepoAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(githubRepoAllowListEnv, tt.args.allowEnv)
+			config.Reload()
 
 			if got := IsGithubRepoAllowed(tt.args.fullName); got != tt.want {
 				t.Errorf("IsGithubRepoAllowed() = %v, want %v", got, tt.want)

--- a/pkg/allow_list/github_test.go
+++ b/pkg/allow_list/github_test.go
@@ -111,7 +111,7 @@ func TestIsGithubRepoAllowed(t *testing.T) {
 			t.Setenv(githubRepoAllowListEnv, tt.args.allowEnv)
 			config.Reload()
 
-			if got := IsGithubRepoAllowed(tt.args.fullName); got != tt.want {
+			if got := IsGithubRepoAllowed(config.C, tt.args.fullName); got != tt.want {
 				t.Errorf("IsGithubRepoAllowed() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/allow_list/gitlab.go
+++ b/pkg/allow_list/gitlab.go
@@ -4,15 +4,16 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 const legacyAllowListEnv = "TFBUDDY_PROJECT_ALLOW_LIST"
 const GitlabProjectAllowListEnv = "TFBUDDY_GITLAB_PROJECT_ALLOW_LIST"
 
-func IsGitlabProjectAllowed(projectWithNamespace string) bool {
-	allowList := getAllowList(GitlabProjectAllowListEnv)
+func IsGitlabProjectAllowed(cfg config.Config, projectWithNamespace string) bool {
+	allowList := getAllowList(cfg, GitlabProjectAllowListEnv)
 	if len(allowList) == 0 {
-		allowList = getAllowList(legacyAllowListEnv)
+		allowList = getAllowList(cfg, legacyAllowListEnv)
 	}
 
 	if len(allowList) == 0 {

--- a/pkg/allow_list/gitlab.go
+++ b/pkg/allow_list/gitlab.go
@@ -7,13 +7,10 @@ import (
 	"github.com/zapier/tfbuddy/internal/config"
 )
 
-const legacyAllowListEnv = "TFBUDDY_PROJECT_ALLOW_LIST"
-const GitlabProjectAllowListEnv = "TFBUDDY_GITLAB_PROJECT_ALLOW_LIST"
-
 func IsGitlabProjectAllowed(cfg config.Config, projectWithNamespace string) bool {
-	allowList := getAllowList(cfg, GitlabProjectAllowListEnv)
+	allowList := getAllowList(cfg.GitlabProjectAllowList)
 	if len(allowList) == 0 {
-		allowList = getAllowList(cfg, legacyAllowListEnv)
+		allowList = getAllowList(cfg.LegacyProjectAllowList)
 	}
 
 	if len(allowList) == 0 {

--- a/pkg/allow_list/gitlab_test.go
+++ b/pkg/allow_list/gitlab_test.go
@@ -112,7 +112,7 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 			t.Setenv(GitlabProjectAllowListEnv, tt.args.allowEnv)
 			config.Reload()
 
-			if got := IsGitlabProjectAllowed(tt.args.projectWithNamespace); got != tt.want {
+			if got := IsGitlabProjectAllowed(config.C, tt.args.projectWithNamespace); got != tt.want {
 				t.Errorf("IsGitlabProjectAllowed() with primary env = %v, want %v", got, tt.want)
 			}
 		})
@@ -122,7 +122,7 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 			t.Setenv(legacyAllowListEnv, tt.args.allowEnv)
 			config.Reload()
 
-			if got := IsGitlabProjectAllowed(tt.args.projectWithNamespace); got != tt.want {
+			if got := IsGitlabProjectAllowed(config.C, tt.args.projectWithNamespace); got != tt.want {
 				t.Errorf("IsGitlabProjectAllowed() with legacy env = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/allow_list/gitlab_test.go
+++ b/pkg/allow_list/gitlab_test.go
@@ -2,6 +2,8 @@ package allow_list
 
 import (
 	"testing"
+
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func TestIsGitlabProjectAllowed(t *testing.T) {
@@ -108,6 +110,7 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 		t.Run(tt.name+"_primary", func(t *testing.T) {
 			t.Setenv(legacyAllowListEnv, "")
 			t.Setenv(GitlabProjectAllowListEnv, tt.args.allowEnv)
+			config.Reload()
 
 			if got := IsGitlabProjectAllowed(tt.args.projectWithNamespace); got != tt.want {
 				t.Errorf("IsGitlabProjectAllowed() with primary env = %v, want %v", got, tt.want)
@@ -117,6 +120,7 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 		t.Run(tt.name+"_legacy", func(t *testing.T) {
 			t.Setenv(GitlabProjectAllowListEnv, "")
 			t.Setenv(legacyAllowListEnv, tt.args.allowEnv)
+			config.Reload()
 
 			if got := IsGitlabProjectAllowed(tt.args.projectWithNamespace); got != tt.want {
 				t.Errorf("IsGitlabProjectAllowed() with legacy env = %v, want %v", got, tt.want)

--- a/pkg/allow_list/gitlab_test.go
+++ b/pkg/allow_list/gitlab_test.go
@@ -108,8 +108,8 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name+"_primary", func(t *testing.T) {
-			t.Setenv(legacyAllowListEnv, "")
-			t.Setenv(GitlabProjectAllowListEnv, tt.args.allowEnv)
+			t.Setenv("TFBUDDY_PROJECT_ALLOW_LIST", "")
+			t.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", tt.args.allowEnv)
 			config.Reload()
 
 			if got := IsGitlabProjectAllowed(config.C, tt.args.projectWithNamespace); got != tt.want {
@@ -118,8 +118,8 @@ func TestIsGitlabProjectAllowed(t *testing.T) {
 		})
 
 		t.Run(tt.name+"_legacy", func(t *testing.T) {
-			t.Setenv(GitlabProjectAllowListEnv, "")
-			t.Setenv(legacyAllowListEnv, tt.args.allowEnv)
+			t.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "")
+			t.Setenv("TFBUDDY_PROJECT_ALLOW_LIST", tt.args.allowEnv)
 			config.Reload()
 
 			if got := IsGitlabProjectAllowed(config.C, tt.args.projectWithNamespace); got != tt.want {

--- a/pkg/allow_list/viper_test.go
+++ b/pkg/allow_list/viper_test.go
@@ -17,7 +17,7 @@ func TestIsGithubRepoAllowedReadsViper(t *testing.T) {
 	viper.Set(config.KeyGithubRepoAllowList, "org")
 	config.Reload()
 
-	if !IsGithubRepoAllowed("org/repo") {
+	if !IsGithubRepoAllowed(config.C, "org/repo") {
 		t.Fatal("IsGithubRepoAllowed() = false, want true")
 	}
 }
@@ -32,7 +32,7 @@ func TestIsGitlabProjectAllowedReadsViper(t *testing.T) {
 	viper.Set(config.KeyGitlabProjectAllowList, "group")
 	config.Reload()
 
-	if !IsGitlabProjectAllowed("group/project") {
+	if !IsGitlabProjectAllowed(config.C, "group/project") {
 		t.Fatal("IsGitlabProjectAllowed() = false, want true")
 	}
 }

--- a/pkg/allow_list/viper_test.go
+++ b/pkg/allow_list/viper_test.go
@@ -1,0 +1,36 @@
+package allow_list
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/zapier/tfbuddy/internal/config"
+)
+
+func TestIsGithubRepoAllowedReadsViper(t *testing.T) {
+	viper.Reset()
+	config.Init()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.Init()
+	})
+	viper.Set(config.KeyGithubRepoAllowList, "org")
+
+	if !IsGithubRepoAllowed("org/repo") {
+		t.Fatal("IsGithubRepoAllowed() = false, want true")
+	}
+}
+
+func TestIsGitlabProjectAllowedReadsViper(t *testing.T) {
+	viper.Reset()
+	config.Init()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.Init()
+	})
+	viper.Set(config.KeyGitlabProjectAllowList, "group")
+
+	if !IsGitlabProjectAllowed("group/project") {
+		t.Fatal("IsGitlabProjectAllowed() = false, want true")
+	}
+}

--- a/pkg/allow_list/viper_test.go
+++ b/pkg/allow_list/viper_test.go
@@ -15,6 +15,7 @@ func TestIsGithubRepoAllowedReadsViper(t *testing.T) {
 		config.Init()
 	})
 	viper.Set(config.KeyGithubRepoAllowList, "org")
+	config.Reload()
 
 	if !IsGithubRepoAllowed("org/repo") {
 		t.Fatal("IsGithubRepoAllowed() = false, want true")
@@ -29,6 +30,7 @@ func TestIsGitlabProjectAllowedReadsViper(t *testing.T) {
 		config.Init()
 	})
 	viper.Set(config.KeyGitlabProjectAllowList, "group")
+	config.Reload()
 
 	if !IsGitlabProjectAllowed("group/project") {
 		t.Fatal("IsGitlabProjectAllowed() = false, want true")

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -28,7 +28,7 @@ func getProperTargetedApplyText(rmd runstream.RunMetadata, run *tfe.Run, wsName 
 		return fmt.Sprintf(howToApplyFormatWithTarget, targets, wsName, targets, manualMRMergeSnippet)
 	}
 }
-func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstream.RunMetadata) (main, toplevel string, resolve bool) {
+func FormatRunStatusCommentBody(cfg config.Config, tfc tfc_api.ApiClient, run *tfe.Run, rmd runstream.RunMetadata) (main, toplevel string, resolve bool) {
 	wsName := run.Workspace.Name
 	org := run.Workspace.Organization.Name
 	runUrl := fmt.Sprintf("https://app.terraform.io/app/%s/workspaces/%s/runs/%s", org, wsName, run.ID)
@@ -103,7 +103,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 	case tfe.RunPolicySoftFailed:
 		// Policy checks executed and soft-failed; approval required in TFC UI
 		log.Trace().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		if config.C.FailCIOnSentinelSoftFail {
+		if cfg.FailCIOnSentinelSoftFail {
 			extraInfo = "Policy Checks: Soft Failed. Review plan and make changes to pass policy checks."
 		} else {
 			extraInfo = "Policy Checks: Soft Failed — approval required in Terraform Cloud before apply can proceed."

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -2,12 +2,11 @@ package comment_formatter
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/terraform_plan"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
@@ -104,13 +103,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 	case tfe.RunPolicySoftFailed:
 		// Policy checks executed and soft-failed; approval required in TFC UI
 		log.Trace().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		failOnSoftEnv := os.Getenv("TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL")
-		failOnSoft, err := strconv.ParseBool(failOnSoftEnv)
-		if err != nil {
-			log.Error().Err(err).Str("env_var", "TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL").Msg("could not parse env var, defaulting to false")
-			failOnSoft = false
-		}
-		if failOnSoft {
+		if config.FailCIOnSentinelSoftFail() {
 			extraInfo = "Policy Checks: Soft Failed. Review plan and make changes to pass policy checks."
 		} else {
 			extraInfo = "Policy Checks: Soft Failed — approval required in Terraform Cloud before apply can proceed."

--- a/pkg/comment_formatter/tfc_status_update.go
+++ b/pkg/comment_formatter/tfc_status_update.go
@@ -103,7 +103,7 @@ func FormatRunStatusCommentBody(tfc tfc_api.ApiClient, run *tfe.Run, rmd runstre
 	case tfe.RunPolicySoftFailed:
 		// Policy checks executed and soft-failed; approval required in TFC UI
 		log.Trace().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		if config.FailCIOnSentinelSoftFail() {
+		if config.C.FailCIOnSentinelSoftFail {
 			extraInfo = "Policy Checks: Soft Failed. Review plan and make changes to pass policy checks."
 		} else {
 			extraInfo = "Policy Checks: Soft Failed — approval required in Terraform Cloud before apply can proceed."

--- a/pkg/git/git_repo.go
+++ b/pkg/git/git_repo.go
@@ -130,9 +130,9 @@ func WalkRepo(s string, d fs.DirEntry, err error) error {
 func GetCloneDepth(envVar string) int {
 	switch envVar {
 	case "TFBUDDY_GITHUB_CLONE_DEPTH":
-		return appconfig.GithubCloneDepth()
+		return appconfig.C.GithubCloneDepth
 	case "TFBUDDY_GITLAB_CLONE_DEPTH":
-		return appconfig.GitlabCloneDepth()
+		return appconfig.C.GitlabCloneDepth
 	}
 
 	val := os.Getenv(envVar)

--- a/pkg/git/git_repo.go
+++ b/pkg/git/git_repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	appconfig "github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/utils"
 )
 
@@ -127,6 +128,13 @@ func WalkRepo(s string, d fs.DirEntry, err error) error {
 
 // GetCloneDepth reads the provided env var and returns an int to be used as git clone depth. Default is 0.
 func GetCloneDepth(envVar string) int {
+	switch envVar {
+	case "TFBUDDY_GITHUB_CLONE_DEPTH":
+		return appconfig.GithubCloneDepth()
+	case "TFBUDDY_GITLAB_CLONE_DEPTH":
+		return appconfig.GitlabCloneDepth()
+	}
+
 	val := os.Getenv(envVar)
 	if val != "" {
 		depth, err := strconv.Atoi(val)

--- a/pkg/git/git_repo.go
+++ b/pkg/git/git_repo.go
@@ -127,12 +127,12 @@ func WalkRepo(s string, d fs.DirEntry, err error) error {
 }
 
 // GetCloneDepth reads the provided env var and returns an int to be used as git clone depth. Default is 0.
-func GetCloneDepth(envVar string) int {
+func GetCloneDepth(cfg appconfig.Config, envVar string) int {
 	switch envVar {
 	case "TFBUDDY_GITHUB_CLONE_DEPTH":
-		return appconfig.C.GithubCloneDepth
+		return cfg.GithubCloneDepth
 	case "TFBUDDY_GITLAB_CLONE_DEPTH":
-		return appconfig.C.GitlabCloneDepth
+		return cfg.GitlabCloneDepth
 	}
 
 	val := os.Getenv(envVar)

--- a/pkg/git/git_repo_test.go
+++ b/pkg/git/git_repo_test.go
@@ -101,15 +101,15 @@ func TestGitCloneDepth(t *testing.T) {
 	defer os.Unsetenv(testVar)
 	t.Run("no value", func(t *testing.T) {
 		os.Unsetenv(testVar)
-		assert.Equal(t, 0, GetCloneDepth(testVar))
+		assert.Equal(t, 0, GetCloneDepth(config.Config{}, testVar))
 	})
 	t.Run("500 depth", func(t *testing.T) {
 		os.Setenv(testVar, "500")
-		assert.Equal(t, 500, GetCloneDepth(testVar))
+		assert.Equal(t, 500, GetCloneDepth(config.Config{}, testVar))
 	})
 	t.Run("invalid value", func(t *testing.T) {
 		os.Setenv(testVar, "somestuff")
-		assert.Equal(t, 0, GetCloneDepth(testVar))
+		assert.Equal(t, 0, GetCloneDepth(config.Config{}, testVar))
 	})
 
 	t.Run("reads viper for owned config", func(t *testing.T) {
@@ -122,6 +122,6 @@ func TestGitCloneDepth(t *testing.T) {
 		viper.Set(config.KeyGithubCloneDepth, 7)
 		config.Reload()
 
-		assert.Equal(t, 7, GetCloneDepth("TFBUDDY_GITHUB_CLONE_DEPTH"))
+		assert.Equal(t, 7, GetCloneDepth(config.C, "TFBUDDY_GITHUB_CLONE_DEPTH"))
 	})
 }

--- a/pkg/git/git_repo_test.go
+++ b/pkg/git/git_repo_test.go
@@ -120,6 +120,7 @@ func TestGitCloneDepth(t *testing.T) {
 			config.Init()
 		})
 		viper.Set(config.KeyGithubCloneDepth, 7)
+		config.Reload()
 
 		assert.Equal(t, 7, GetCloneDepth("TFBUDDY_GITHUB_CLONE_DEPTH"))
 	})

--- a/pkg/git/git_repo_test.go
+++ b/pkg/git/git_repo_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/mocks"
 )
 
@@ -108,5 +110,17 @@ func TestGitCloneDepth(t *testing.T) {
 	t.Run("invalid value", func(t *testing.T) {
 		os.Setenv(testVar, "somestuff")
 		assert.Equal(t, 0, GetCloneDepth(testVar))
+	})
+
+	t.Run("reads viper for owned config", func(t *testing.T) {
+		viper.Reset()
+		config.Init()
+		t.Cleanup(func() {
+			viper.Reset()
+			config.Init()
+		})
+		viper.Set(config.KeyGithubCloneDepth, 7)
+
+		assert.Equal(t, 7, GetCloneDepth("TFBUDDY_GITHUB_CLONE_DEPTH"))
 	})
 }

--- a/pkg/gitlab_hooks/comment_actions.go
+++ b/pkg/gitlab_hooks/comment_actions.go
@@ -21,7 +21,7 @@ func (w *GitlabEventWorker) processNoteEvent(ctx context.Context, event vcs.MRCo
 	defer span.End()
 
 	proj := event.GetProject().GetPathWithNamespace()
-	if !allow_list.IsGitlabProjectAllowed(proj) {
+	if !allow_list.IsGitlabProjectAllowed(w.cfg, proj) {
 		return proj, nil
 	}
 
@@ -51,7 +51,7 @@ func (w *GitlabEventWorker) processNoteEvent(ctx context.Context, event vcs.MRCo
 		return proj, err
 	}
 
-	trigger := w.triggerCreation(w.gl, w.tfc, w.runstream, cfg)
+	trigger := w.triggerCreation(w.cfg, w.gl, w.tfc, w.runstream, cfg)
 
 	if event.GetAttributes().GetType() == string(gitlab.DiscussionNote) {
 		trigger.SetMergeRequestDiscussionID(event.GetAttributes().GetDiscussionID())

--- a/pkg/gitlab_hooks/comment_actions_test.go
+++ b/pkg/gitlab_hooks/comment_actions_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/zapier/tfbuddy/internal/config"
-	"github.com/zapier/tfbuddy/pkg/allow_list"
 	"github.com/zapier/tfbuddy/pkg/comment_actions"
 
 	"github.com/stretchr/testify/assert"
@@ -114,10 +113,12 @@ func Test_parseCommentCommand(t *testing.T) {
 }
 
 func TestProcessNoteEventPlanError(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -172,10 +173,12 @@ func TestProcessNoteEventPlanError(t *testing.T) {
 }
 
 func TestProcessNoteEventPanicHandling(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -204,10 +207,12 @@ func TestProcessNoteEventPanicHandling(t *testing.T) {
 	}
 }
 func TestProcessNoteEventPlan(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockGitClient := mocks.NewMockGitClient(mockCtrl)
@@ -261,10 +266,12 @@ func TestProcessNoteEventPlan(t *testing.T) {
 }
 
 func TestProcessNoteEventPlanFailedWorkspace(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -320,10 +327,12 @@ func TestProcessNoteEventPlanFailedWorkspace(t *testing.T) {
 }
 
 func TestProcessNoteEventPlanFailedMultipleWorkspaces(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -381,10 +390,12 @@ func TestProcessNoteEventPlanFailedMultipleWorkspaces(t *testing.T) {
 }
 
 func TestProcessNoteEventNoErrorNoRuns(t *testing.T) {
-	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	os.Setenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST", "zapier/")
 	config.Reload()
-	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
-	defer config.Reload()
+	defer func() {
+		os.Unsetenv("TFBUDDY_GITLAB_PROJECT_ALLOW_LIST")
+		config.Reload()
+	}()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockGitClient := mocks.NewMockGitClient(mockCtrl)

--- a/pkg/gitlab_hooks/comment_actions_test.go
+++ b/pkg/gitlab_hooks/comment_actions_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/allow_list"
 	"github.com/zapier/tfbuddy/pkg/comment_actions"
 
@@ -114,7 +115,9 @@ func Test_parseCommentCommand(t *testing.T) {
 
 func TestProcessNoteEventPlanError(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -198,7 +201,9 @@ func TestProcessNoteEventPanicHandling(t *testing.T) {
 }
 func TestProcessNoteEventPlan(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockGitClient := mocks.NewMockGitClient(mockCtrl)
@@ -252,7 +257,9 @@ func TestProcessNoteEventPlan(t *testing.T) {
 
 func TestProcessNoteEventPlanFailedWorkspace(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -308,7 +315,9 @@ func TestProcessNoteEventPlanFailedWorkspace(t *testing.T) {
 
 func TestProcessNoteEventPlanFailedMultipleWorkspaces(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -366,7 +375,9 @@ func TestProcessNoteEventPlanFailedMultipleWorkspaces(t *testing.T) {
 
 func TestProcessNoteEventNoErrorNoRuns(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockGitClient := mocks.NewMockGitClient(mockCtrl)

--- a/pkg/gitlab_hooks/comment_actions_test.go
+++ b/pkg/gitlab_hooks/comment_actions_test.go
@@ -151,10 +151,11 @@ func TestProcessNoteEventPlanError(t *testing.T) {
 	mockTFCTrigger.EXPECT().TriggerTFCEvents(gomock.Any()).Return(nil, fmt.Errorf("something went wrong"))
 
 	client := &GitlabEventWorker{
+		cfg:       config.C,
 		gl:        mockGitClient,
 		tfc:       mockApiClient,
 		runstream: mockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return mockTFCTrigger
 		},
 	}
@@ -172,7 +173,9 @@ func TestProcessNoteEventPlanError(t *testing.T) {
 
 func TestProcessNoteEventPanicHandling(t *testing.T) {
 	os.Setenv(allow_list.GitlabProjectAllowListEnv, "zapier/")
+	config.Reload()
 	defer os.Unsetenv(allow_list.GitlabProjectAllowListEnv)
+	defer config.Reload()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
@@ -184,10 +187,11 @@ func TestProcessNoteEventPanicHandling(t *testing.T) {
 
 	testSuite.InitTestSuite()
 	client := &GitlabEventWorker{
+		cfg:       config.C,
 		gl:        testSuite.MockGitClient,
 		tfc:       testSuite.MockApiClient,
 		runstream: testSuite.MockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return nil
 		},
 	}
@@ -238,10 +242,11 @@ func TestProcessNoteEventPlan(t *testing.T) {
 	}, nil)
 
 	client := &GitlabEventWorker{
+		cfg:       config.C,
 		gl:        mockGitClient,
 		tfc:       mockApiClient,
 		runstream: mockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return mockTFCTrigger
 		},
 	}
@@ -296,10 +301,11 @@ func TestProcessNoteEventPlanFailedWorkspace(t *testing.T) {
 	testSuite.InitTestSuite()
 
 	worker := &GitlabEventWorker{
+		cfg:       config.C,
 		tfc:       testSuite.MockApiClient,
 		gl:        testSuite.MockGitClient,
 		runstream: testSuite.MockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return mockTFCTrigger
 		},
 	}
@@ -356,10 +362,11 @@ func TestProcessNoteEventPlanFailedMultipleWorkspaces(t *testing.T) {
 	testSuite.InitTestSuite()
 
 	client := &GitlabEventWorker{
+		cfg:       config.C,
 		gl:        testSuite.MockGitClient,
 		tfc:       testSuite.MockApiClient,
 		runstream: testSuite.MockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return mockTFCTrigger
 		},
 	}
@@ -410,10 +417,11 @@ func TestProcessNoteEventNoErrorNoRuns(t *testing.T) {
 	mockTFCTrigger.EXPECT().TriggerTFCEvents(gomock.Any()).Return(nil, nil)
 
 	client := &GitlabEventWorker{
+		cfg:       config.C,
 		gl:        mockGitClient,
 		tfc:       mockApiClient,
 		runstream: mockStreamClient,
-		triggerCreation: func(gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
+		triggerCreation: func(appCfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, runstream runstream.StreamClient, cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger {
 			return mockTFCTrigger
 		},
 	}

--- a/pkg/gitlab_hooks/handler.go
+++ b/pkg/gitlab_hooks/handler.go
@@ -57,7 +57,7 @@ func NewGitlabHooksHandler(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 		mrStream:        mrStream,
 		notesStream:     notesStream,
-		hookSecretKey:   config.GitlabHookSecretKey(),
+		hookSecretKey:   config.C.GitlabHookSecretKey,
 	}
 
 	h.hooksWorker = NewGitlabEventWorker(h, js)

--- a/pkg/gitlab_hooks/handler.go
+++ b/pkg/gitlab_hooks/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sl1pm4t/gongs"
@@ -18,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
@@ -47,7 +47,6 @@ type GitlabHooksHandler struct {
 }
 
 func NewGitlabHooksHandler(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GitlabHooksHandler {
-	hookSecretEnv := os.Getenv("TFBUDDY_GITLAB_HOOK_SECRET_KEY")
 	notesStream := gongs.NewGenericStream[NoteEventMsg](js, noteEventsStreamSubject(), hooks_stream.HooksStreamName)
 	mrStream := gongs.NewGenericStream[MergeRequestEventMsg](js, mrEventsStreamSubject(), hooks_stream.HooksStreamName)
 
@@ -58,7 +57,7 @@ func NewGitlabHooksHandler(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 		mrStream:        mrStream,
 		notesStream:     notesStream,
-		hookSecretKey:   hookSecretEnv,
+		hookSecretKey:   config.GitlabHookSecretKey(),
 	}
 
 	h.hooksWorker = NewGitlabEventWorker(h, js)

--- a/pkg/gitlab_hooks/handler.go
+++ b/pkg/gitlab_hooks/handler.go
@@ -28,12 +28,14 @@ import (
 const GitlabTokenHeader = "X-Gitlab-Token"
 const GitlabHookIgnoreReasonUnhandledEventType = "unhandled-event-type"
 
-type TriggerCreationFunc func(gl vcs.GitClient,
+type TriggerCreationFunc func(appCfg config.Config,
+	gl vcs.GitClient,
 	tfc tfc_api.ApiClient,
 	runstream runstream.StreamClient,
-	cfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger
+	triggerCfg *tfc_trigger.TFCTriggerOptions) tfc_trigger.Trigger
 
 type GitlabHooksHandler struct {
+	cfg             config.Config
 	tfc             tfc_api.ApiClient
 	gl              vcs.GitClient
 	runstream       runstream.StreamClient
@@ -46,18 +48,19 @@ type GitlabHooksHandler struct {
 	hooksWorker   *GitlabEventWorker
 }
 
-func NewGitlabHooksHandler(gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GitlabHooksHandler {
+func NewGitlabHooksHandler(cfg config.Config, gl vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GitlabHooksHandler {
 	notesStream := gongs.NewGenericStream[NoteEventMsg](js, noteEventsStreamSubject(), hooks_stream.HooksStreamName)
 	mrStream := gongs.NewGenericStream[MergeRequestEventMsg](js, mrEventsStreamSubject(), hooks_stream.HooksStreamName)
 
 	h := &GitlabHooksHandler{
+		cfg:             cfg,
 		tfc:             tfc,
 		gl:              gl,
 		runstream:       rs,
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 		mrStream:        mrStream,
 		notesStream:     notesStream,
-		hookSecretKey:   config.C.GitlabHookSecretKey,
+		hookSecretKey:   cfg.GitlabHookSecretKey,
 	}
 
 	h.hooksWorker = NewGitlabEventWorker(h, js)

--- a/pkg/gitlab_hooks/hook_worker.go
+++ b/pkg/gitlab_hooks/hook_worker.go
@@ -3,6 +3,7 @@ package gitlab_hooks
 import (
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
@@ -12,6 +13,7 @@ import (
 )
 
 type GitlabEventWorker struct {
+	cfg             config.Config
 	tfc             tfc_api.ApiClient
 	gl              vcs.GitClient
 	runstream       runstream.StreamClient
@@ -20,6 +22,7 @@ type GitlabEventWorker struct {
 
 func NewGitlabEventWorker(h *GitlabHooksHandler, js nats.JetStreamContext) *GitlabEventWorker {
 	w := &GitlabEventWorker{
+		cfg:             h.cfg,
 		tfc:             h.tfc,
 		gl:              h.gl,
 		runstream:       h.runstream,

--- a/pkg/gitlab_hooks/mr_actions.go
+++ b/pkg/gitlab_hooks/mr_actions.go
@@ -22,7 +22,7 @@ func (w *GitlabEventWorker) processMergeRequestEvent(msg *MergeRequestEventMsg) 
 
 	projectName = event.Project.PathWithNamespace
 	labels["project"] = projectName
-	if !allow_list.IsGitlabProjectAllowed(event.Project.PathWithNamespace) {
+	if !allow_list.IsGitlabProjectAllowed(w.cfg, event.Project.PathWithNamespace) {
 		log.Warn().Str("project", event.Project.Name).Msg("project not authorized")
 		labels["reason"] = "project-not-authorized"
 		gitlabWebHookIgnored.With(labels).Inc()
@@ -43,7 +43,7 @@ func (w *GitlabEventWorker) processMergeRequestEvent(msg *MergeRequestEventMsg) 
 		return projectName, err
 	}
 
-	trigger := tfc_trigger.NewTFCTrigger(w.gl, w.tfc, w.runstream, cfg)
+	trigger := tfc_trigger.NewTFCTrigger(w.cfg, w.gl, w.tfc, w.runstream, cfg)
 	switch event.ObjectAttributes.Action {
 	case "open", "reopen":
 		log.Debug().Str("project", projectName).Int("mergeRequestID", event.ObjectAttributes.IID).Msg("triggering TFC events for merge request")

--- a/pkg/hooks/server.go
+++ b/pkg/hooks/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/hooks_stream"
 	"github.com/zapier/tfbuddy/pkg/vcs/github"
 	"github.com/ziflex/lecho/v3"
@@ -21,7 +22,7 @@ import (
 	"github.com/zapier/tfbuddy/pkg/vcs/gitlab"
 )
 
-func StartServer() {
+func StartServer(cfg config.Config) {
 	e := echo.New()
 	e.HideBanner = true
 	e.Use(middleware.Recover())
@@ -36,7 +37,7 @@ func StartServer() {
 	e.GET("/live", echo.WrapHandler(health))
 
 	// setup NATS client & streams
-	nc := tfnats.Connect()
+	nc := tfnats.Connect(cfg)
 	js, err := nc.JetStream(nats.PublishAsyncMaxPending(256))
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not create Jetstream context")
@@ -50,7 +51,7 @@ func StartServer() {
 	health.AddLivenessCheck("hook-stream", hs.HealthCheck)
 
 	// setup API clients
-	gl := gitlab.NewGitlabClient()
+	gl := gitlab.NewGitlabClient(cfg)
 	tfc := tfc_api.NewTFCClient()
 
 	hooksGroup := e.Group("/hooks")
@@ -67,14 +68,14 @@ func StartServer() {
 	//
 	// Github
 	//
-	gh := github.NewGithubClient()
-	githubHooksHandler := ghHooks.NewGithubHooksHandler(gh, tfc, rs, js)
+	gh := github.NewGithubClient(cfg)
+	githubHooksHandler := ghHooks.NewGithubHooksHandler(cfg, gh, tfc, rs, js)
 	hooksGroup.POST("/github/events", githubHooksHandler.Handler)
 
 	//
 	// Gitlab
 	//
-	gitlabGroupHandler := gitlab_hooks.NewGitlabHooksHandler(gl, tfc, rs, js)
+	gitlabGroupHandler := gitlab_hooks.NewGitlabHooksHandler(cfg, gl, tfc, rs, js)
 	hooksGroup.POST("/gitlab/group", gitlabGroupHandler.GroupHandler())
 	hooksGroup.POST("/gitlab/project", gitlabGroupHandler.ProjectHandler())
 
@@ -87,11 +88,11 @@ func StartServer() {
 	hooksGroup.POST("/tfc/notification", notifHandler.Handler())
 
 	// Github Run Events Processor
-	ghep := github.NewRunEventsWorker(gh, rs, tfc)
+	ghep := github.NewRunEventsWorker(cfg, gh, rs, tfc)
 	defer ghep.Close()
 
 	// Gitlab Run Events Processor
-	grsp := gitlab.NewRunStatusProcessor(gl, rs, tfc)
+	grsp := gitlab.NewRunStatusProcessor(cfg, gl, rs, tfc)
 	defer grsp.Close()
 
 	if err := e.Start(":8080"); err != nil {

--- a/pkg/nats/nats_client.go
+++ b/pkg/nats/nats_client.go
@@ -6,8 +6,8 @@ import (
 	"github.com/zapier/tfbuddy/internal/config"
 )
 
-func Connect() *nats.Conn {
-	natsURL := config.C.NATSServiceURL
+func Connect(cfg config.Config) *nats.Conn {
+	natsURL := cfg.NATSServiceURL
 	if natsURL == "" {
 		// try default
 		natsURL = nats.DefaultURL

--- a/pkg/nats/nats_client.go
+++ b/pkg/nats/nats_client.go
@@ -1,14 +1,13 @@
 package nats
 
 import (
-	"os"
-
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 func Connect() *nats.Conn {
-	natsURL := os.Getenv("TFBUDDY_NATS_SERVICE_URL")
+	natsURL := config.NATSServiceURL()
 	if natsURL == "" {
 		// try default
 		natsURL = nats.DefaultURL

--- a/pkg/nats/nats_client.go
+++ b/pkg/nats/nats_client.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Connect() *nats.Conn {
-	natsURL := config.NATSServiceURL()
+	natsURL := config.C.NATSServiceURL
 	if natsURL == "" {
 		// try default
 		natsURL = nats.DefaultURL

--- a/pkg/runstream/run_metadata.go
+++ b/pkg/runstream/run_metadata.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
-	"github.com/zapier/tfbuddy/pkg/vcs"
 )
 
 // ensure type complies with interface
@@ -79,7 +78,7 @@ func (r *TFRunMetadata) GetVcsProvider() string {
 	return r.VcsProvider
 }
 func (r *TFRunMetadata) GetAutoMerge() bool {
-	return r.AutoMerge && vcs.IsGlobalAutoMergeEnabled()
+	return r.AutoMerge
 }
 func (s *Stream) AddRunMeta(rmd RunMetadata) error {
 	b, err := encodeTFRunMetadata(rmd)

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -218,5 +218,5 @@ func (s *TFCWorkspace) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func getDefaultOrgName() string {
-	return config.DefaultTFCOrganization()
+	return config.C.DefaultTFCOrganization
 }

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -175,21 +175,21 @@ func getProjectConfigFile(ctx context.Context, gl vcs.GitClient, trigger *TFCTri
 			log.Info().Err(err).Msg(fmt.Sprintf("no file on branch %s", branch))
 			continue
 		}
-		return loadProjectConfig(b)
+		return loadProjectConfig(trigger.appCfg, b)
 	}
 	log.Warn().Msg("could not retrieve .tfbuddy.yaml for repo")
 
 	return nil, utils.CreatePermanentError(errors.New("could not retrieve .tfbuddy.yaml for repo"))
 }
 
-func loadProjectConfig(b []byte) (*ProjectConfig, error) {
+func loadProjectConfig(appCfg config.Config, b []byte) (*ProjectConfig, error) {
 	cfg := &ProjectConfig{}
 	err := yaml.Unmarshal(b, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse Project config file (.tfbuddy.yaml): %v. %w", err, utils.ErrPermanent)
 	}
 
-	defaultOrgName := getDefaultOrgName()
+	defaultOrgName := getDefaultOrgName(appCfg)
 	for _, ws := range cfg.Workspaces {
 		if ws.Organization == "" {
 			ws.Organization = defaultOrgName
@@ -217,6 +217,6 @@ func (s *TFCWorkspace) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func getDefaultOrgName() string {
-	return config.C.DefaultTFCOrganization
+func getDefaultOrgName(appCfg config.Config) string {
+	return appCfg.DefaultTFCOrganization
 }

--- a/pkg/tfc_trigger/project_config.go
+++ b/pkg/tfc_trigger/project_config.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/creasty/defaults"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/utils"
 	"github.com/zapier/tfbuddy/pkg/vcs"
 	"go.opentelemetry.io/otel"
@@ -26,7 +26,7 @@ type ProjectConfig struct {
 
 // Finds the workspace with the deepest matching directory suffix.
 // For example, given workspaces with config "terraform/dev/" and a dir of "dev/",
-// and a filepath directory of "filesystem/terraform/dev/" - "dev" and "terraform/dev/" are both a suffix 
+// and a filepath directory of "filesystem/terraform/dev/" - "dev" and "terraform/dev/" are both a suffix
 // we would return the ws for "terraform/dev/"as it is the deepest match.
 // Special case: if a workspace has config "/" and the input dir is ".", that workspace is returned.
 // If no workspace matches, returns nil.
@@ -47,7 +47,7 @@ func (cfg *ProjectConfig) workspaceForDir(dir string) *TFCWorkspace {
 			continue
 		}
 
-		if (strings.HasSuffix(dir+"/", wsDir) || strings.HasSuffix(dir, wsDir)) {
+		if strings.HasSuffix(dir+"/", wsDir) || strings.HasSuffix(dir, wsDir) {
 			wsDirDepth := len(strings.Split(wsDir, "/"))
 			if wsDirDepth > longestMatchDepth {
 				longestMatch = ws
@@ -218,5 +218,5 @@ func (s *TFCWorkspace) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func getDefaultOrgName() string {
-	return os.Getenv(DefaultTfcOrganizationEnvName)
+	return config.DefaultTFCOrganization()
 }

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/zapier/tfbuddy/internal/config"
 
 	"github.com/kr/pretty"
 )
@@ -505,9 +506,11 @@ func Test_loadProjectConfig(t *testing.T) {
 			args: args{b: []byte(tfbuddyYamlNoOrg)},
 			preTestFn: func() {
 				os.Setenv(DefaultTfcOrganizationEnvName, "foo-corp")
+				config.Reload()
 			},
 			postTestFn: func() {
 				os.Unsetenv(DefaultTfcOrganizationEnvName)
+				config.Reload()
 			},
 			want: &ProjectConfig{Workspaces: []*TFCWorkspace{
 				{

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -605,7 +605,7 @@ func Test_loadProjectConfig(t *testing.T) {
 			if tt.preTestFn != nil {
 				tt.preTestFn()
 			}
-			got, err := loadProjectConfig(tt.args.b)
+			got, err := loadProjectConfig(config.C, tt.args.b)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadProjectConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -778,7 +778,7 @@ func TestHasChangesForWorkspace(t *testing.T) {
 }
 
 func testLoadConfig(t *testing.T, yaml string) *ProjectConfig {
-	pc, err := loadProjectConfig([]byte(yaml))
+	pc, err := loadProjectConfig(config.C, []byte(yaml))
 	if err != nil {
 		t.Errorf("could not load ProjectConfig for test: %v", err)
 	}

--- a/pkg/tfc_trigger/project_config_test.go
+++ b/pkg/tfc_trigger/project_config_test.go
@@ -505,11 +505,11 @@ func Test_loadProjectConfig(t *testing.T) {
 			name: "no-organization-w-default",
 			args: args{b: []byte(tfbuddyYamlNoOrg)},
 			preTestFn: func() {
-				os.Setenv(DefaultTfcOrganizationEnvName, "foo-corp")
+				os.Setenv("TFBUDDY_DEFAULT_TFC_ORGANIZATION", "foo-corp")
 				config.Reload()
 			},
 			postTestFn: func() {
-				os.Unsetenv(DefaultTfcOrganizationEnvName)
+				os.Unsetenv("TFBUDDY_DEFAULT_TFC_ORGANIZATION")
 				config.Reload()
 			},
 			want: &ProjectConfig{Workspaces: []*TFCWorkspace{

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
@@ -82,6 +83,7 @@ const (
 )
 
 type TFCTrigger struct {
+	appCfg    config.Config
 	cfg       *TFCTriggerOptions
 	gl        vcs.GitClient
 	tfc       tfc_api.ApiClient
@@ -122,6 +124,7 @@ func (tfcOpts *TFCTriggerOptions) validate() error {
 }
 
 func NewTFCTrigger(
+	appCfg config.Config,
 	gl vcs.GitClient,
 	tfc tfc_api.ApiClient,
 	runstream runstream.StreamClient,
@@ -129,6 +132,7 @@ func NewTFCTrigger(
 ) Trigger {
 
 	return &TFCTrigger{
+		appCfg:    appCfg,
 		gl:        gl,
 		tfc:       tfc,
 		cfg:       cfg,
@@ -406,7 +410,7 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 		}
 		for _, cfgWS := range triggeredWorkspaces {
 			// check allow / deny lists
-			if !isWorkspaceAllowed(cfgWS.Name, cfgWS.Organization) {
+			if !isWorkspaceAllowed(t.appCfg, cfgWS.Name, cfgWS.Organization) {
 				log.Info().Str("ws", cfgWS.Name).Msg("Ignoring workspace, because of allow/deny list.")
 				workspaceStatus.Errored = append(workspaceStatus.Errored, &ErroredWorkspace{
 					Name:  cfgWS.Name,
@@ -703,7 +707,7 @@ func (t *TFCTrigger) publishRunToStream(ctx context.Context, run *tfe.Run, cfgWS
 			Str("WS", run.Workspace.Name).Msg("auto-merge cannot be enabled because the 'apply-before-merge' mode is not in use")
 		rmd.AutoMerge = false
 	}
-	if cfgWS.AutoMerge && !vcs.IsGlobalAutoMergeEnabled() {
+	if cfgWS.AutoMerge && !t.appCfg.AllowAutoMerge {
 		log.Info().Str("RunID", run.ID).
 			Str("Org", run.Workspace.Organization.Name).
 			Str("WS", run.Workspace.Name).Msg("auto-merge cannot be enabled since the feature is globally disabled")

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
-	"github.com/zapier/tfbuddy/pkg/vcs"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/mock/gomock"
 )
@@ -732,11 +731,13 @@ func TestAutoMerge_True_Apply_Before_Merge(t *testing.T) {
 }
 
 func TestAutoMerge_Globally_Disabled(t *testing.T) {
-	originalVal := os.Getenv(vcs.TF_BUDDY_AUTO_MERGE)
-	os.Setenv(vcs.TF_BUDDY_AUTO_MERGE, "false")
+	originalVal := os.Getenv("TFBUDDY_ALLOW_AUTO_MERGE")
+	os.Setenv("TFBUDDY_ALLOW_AUTO_MERGE", "false")
 	config.Reload()
-	defer func() { os.Setenv(vcs.TF_BUDDY_AUTO_MERGE, originalVal) }()
-	defer config.Reload()
+	defer func() {
+		os.Setenv("TFBUDDY_ALLOW_AUTO_MERGE", originalVal)
+		config.Reload()
+	}()
 
 	ws := &tfc_trigger.ProjectConfig{
 		Workspaces: []*tfc_trigger.TFCWorkspace{{

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -133,7 +133,7 @@ func TestTFCEvents_SingleWorkspacePlan(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	triggeredWS, err := trigger.TriggerTFCEvents(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +179,7 @@ func TestTFCEvents_SingleWorkspacePlanError(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	triggeredWS, err := trigger.TriggerTFCEvents(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -236,7 +236,7 @@ func TestTFCEvents_SingleWorkspaceApply(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -310,7 +310,7 @@ func TestTFCEvents_MultiWorkspaceApply(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -371,7 +371,7 @@ func TestTFCEvents_SingleWorkspaceApplyError(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	triggeredWS, err := trigger.TriggerTFCEvents(context.Background())
 	if err == nil {
 		t.Fatal("expected error to be returned")
@@ -440,7 +440,7 @@ func TestTFCEvents_MultiWorkspaceApplyError(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -490,7 +490,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, mockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, mockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -559,7 +559,7 @@ func TestTFCEvents_MultiWorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 		Workspace:                "",
 		CommitSHA:                "abcd12233",
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -633,7 +633,7 @@ func TestAutoMerge_False_Merge_Before_Apply(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -706,7 +706,7 @@ func TestAutoMerge_True_Apply_Before_Merge(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -785,7 +785,7 @@ func TestAutoMerge_Globally_Disabled(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -861,7 +861,7 @@ func TestTFCEvents_ApplyNotBlockedByDifferentServiceChanges(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -927,7 +927,7 @@ func TestTFCEvents_StaleLock_MergedMR_AutoCleans(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -978,7 +978,7 @@ func TestTFCEvents_StaleLock_OpenMR_Rejects(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -1030,7 +1030,7 @@ func TestTFCEvents_StaleLock_RemovalFailure_Errors(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -1092,7 +1092,7 @@ func TestTFCEvents_UnlockRemovesTags(t *testing.T) {
 		TriggerSource:            tfc_trigger.CommentTrigger,
 		Workspace:                "service-tfbuddy",
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {
@@ -1153,7 +1153,7 @@ func TestTriggerCleanupEvent_ScopesCleanupToTriggeredWorkspaces(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	if err := trigger.TriggerCleanupEvent(ctx); err != nil {
 		t.Fatalf("cleanup should not fail when unrelated workspaces exist, got: %v", err)
@@ -1198,7 +1198,7 @@ func TestTriggerCleanupEvent_DoesNotReleaseOtherMRsLocks(t *testing.T) {
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.MergeRequestEventTrigger,
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	if err := trigger.TriggerCleanupEvent(ctx); err != nil {
 		t.Fatalf("cleanup should not fail, got: %v", err)
@@ -1247,7 +1247,7 @@ func TestTFCEvents_UnlockAlreadyUnlocked_StillRemovesTags(t *testing.T) {
 		TriggerSource:            tfc_trigger.CommentTrigger,
 		Workspace:                "service-tfbuddy",
 	})
-	trigger := tfc_trigger.NewTFCTrigger(testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
 	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
 	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
 	if err != nil {

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
 	"github.com/rzajac/zltest"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/mocks"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
@@ -733,7 +734,9 @@ func TestAutoMerge_True_Apply_Before_Merge(t *testing.T) {
 func TestAutoMerge_Globally_Disabled(t *testing.T) {
 	originalVal := os.Getenv(vcs.TF_BUDDY_AUTO_MERGE)
 	os.Setenv(vcs.TF_BUDDY_AUTO_MERGE, "false")
+	config.Reload()
 	defer func() { os.Setenv(vcs.TF_BUDDY_AUTO_MERGE, originalVal) }()
+	defer config.Reload()
 
 	ws := &tfc_trigger.ProjectConfig{
 		Workspaces: []*tfc_trigger.TFCWorkspace{{

--- a/pkg/tfc_trigger/workspace_allowdeny_list.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list.go
@@ -1,10 +1,10 @@
 package tfc_trigger
 
 import (
-	"os"
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
 const DefaultTfcOrganizationEnvName = "TFBUDDY_DEFAULT_TFC_ORGANIZATION"
@@ -14,27 +14,19 @@ func getWorkspaceAllowDenyList() ([]string, []string) {
 	// if a workspace in the allow list does not include a org component, prepend this value (if defined).
 	workspaceAllowList := make([]string, 0)
 	workspaceDenyList := make([]string, 0)
-	defaultOrg := os.Getenv(DefaultTfcOrganizationEnvName)
+	defaultOrg := config.DefaultTFCOrganization()
 
-	allowEnv := os.Getenv("TFBUDDY_WORKSPACE_ALLOW_LIST")
-	if allowEnv != "" {
-		allowed := strings.Split(allowEnv, ",")
-		for _, w := range allowed {
-			ws := strings.TrimSpace(w)
-			ws = strings.ToLower(ws)
-			if !strings.Contains(ws, "/") {
-				ws = defaultOrg + "/" + ws
-			}
-			log.Info().Str("workspace", ws).Msg("adding Workspace to allow list")
-			workspaceAllowList = append(workspaceAllowList, ws)
+	for _, w := range config.WorkspaceAllowList() {
+		ws := strings.ToLower(strings.TrimSpace(w))
+		if !strings.Contains(ws, "/") {
+			ws = defaultOrg + "/" + ws
 		}
+		log.Info().Str("workspace", ws).Msg("adding Workspace to allow list")
+		workspaceAllowList = append(workspaceAllowList, ws)
 	}
 
-	denyEnv := os.Getenv("TFBUDDY_WORKSPACE_DENY_LIST")
-	denied := strings.Split(denyEnv, ",")
-	for _, w := range denied {
-		ws := strings.TrimSpace(w)
-		ws = strings.ToLower(ws)
+	for _, w := range config.WorkspaceDenyList() {
+		ws := strings.ToLower(strings.TrimSpace(w))
 		if !strings.Contains(ws, "/") {
 			ws = defaultOrg + "/" + ws
 		}

--- a/pkg/tfc_trigger/workspace_allowdeny_list.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list.go
@@ -10,13 +10,13 @@ import (
 const DefaultTfcOrganizationEnvName = "TFBUDDY_DEFAULT_TFC_ORGANIZATION"
 
 // getWorkspaceAllowDenyList returns a list of allowed and denied workspaces
-func getWorkspaceAllowDenyList() ([]string, []string) {
+func getWorkspaceAllowDenyList(cfg config.Config) ([]string, []string) {
 	// if a workspace in the allow list does not include a org component, prepend this value (if defined).
 	workspaceAllowList := make([]string, 0)
 	workspaceDenyList := make([]string, 0)
-	defaultOrg := config.C.DefaultTFCOrganization
+	defaultOrg := cfg.DefaultTFCOrganization
 
-	for _, w := range config.C.WorkspaceAllowList {
+	for _, w := range cfg.WorkspaceAllowList {
 		ws := strings.ToLower(strings.TrimSpace(w))
 		if !strings.Contains(ws, "/") {
 			ws = defaultOrg + "/" + ws
@@ -25,7 +25,7 @@ func getWorkspaceAllowDenyList() ([]string, []string) {
 		workspaceAllowList = append(workspaceAllowList, ws)
 	}
 
-	for _, w := range config.C.WorkspaceDenyList {
+	for _, w := range cfg.WorkspaceDenyList {
 		ws := strings.ToLower(strings.TrimSpace(w))
 		if !strings.Contains(ws, "/") {
 			ws = defaultOrg + "/" + ws
@@ -36,8 +36,8 @@ func getWorkspaceAllowDenyList() ([]string, []string) {
 	return workspaceAllowList, workspaceDenyList
 }
 
-func isWorkspaceAllowed(workspace, org string) bool {
-	workspaceAllowList, workspaceDenyList := getWorkspaceAllowDenyList()
+func isWorkspaceAllowed(cfg config.Config, workspace, org string) bool {
+	workspaceAllowList, workspaceDenyList := getWorkspaceAllowDenyList(cfg)
 	fullName := org + "/" + workspace
 	for _, denied := range workspaceDenyList {
 		if fullName == denied {

--- a/pkg/tfc_trigger/workspace_allowdeny_list.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list.go
@@ -14,9 +14,9 @@ func getWorkspaceAllowDenyList() ([]string, []string) {
 	// if a workspace in the allow list does not include a org component, prepend this value (if defined).
 	workspaceAllowList := make([]string, 0)
 	workspaceDenyList := make([]string, 0)
-	defaultOrg := config.DefaultTFCOrganization()
+	defaultOrg := config.C.DefaultTFCOrganization
 
-	for _, w := range config.WorkspaceAllowList() {
+	for _, w := range config.C.WorkspaceAllowList {
 		ws := strings.ToLower(strings.TrimSpace(w))
 		if !strings.Contains(ws, "/") {
 			ws = defaultOrg + "/" + ws
@@ -25,7 +25,7 @@ func getWorkspaceAllowDenyList() ([]string, []string) {
 		workspaceAllowList = append(workspaceAllowList, ws)
 	}
 
-	for _, w := range config.WorkspaceDenyList() {
+	for _, w := range config.C.WorkspaceDenyList {
 		ws := strings.ToLower(strings.TrimSpace(w))
 		if !strings.Contains(ws, "/") {
 			ws = defaultOrg + "/" + ws

--- a/pkg/tfc_trigger/workspace_allowdeny_list.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list.go
@@ -7,8 +7,6 @@ import (
 	"github.com/zapier/tfbuddy/internal/config"
 )
 
-const DefaultTfcOrganizationEnvName = "TFBUDDY_DEFAULT_TFC_ORGANIZATION"
-
 // getWorkspaceAllowDenyList returns a list of allowed and denied workspaces
 func getWorkspaceAllowDenyList(cfg config.Config) ([]string, []string) {
 	// if a workspace in the allow list does not include a org component, prepend this value (if defined).

--- a/pkg/tfc_trigger/workspace_allowdeny_list_test.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list_test.go
@@ -18,6 +18,7 @@ func TestGetWorkspaceAllowDenyListReadsViper(t *testing.T) {
 	viper.Set(config.KeyDefaultTFCOrganization, "zapier")
 	viper.Set(config.KeyWorkspaceAllowList, "svc-a, org-b/svc-b")
 	viper.Set(config.KeyWorkspaceDenyList, "svc-c")
+	config.Reload()
 
 	allow, deny := getWorkspaceAllowDenyList()
 

--- a/pkg/tfc_trigger/workspace_allowdeny_list_test.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list_test.go
@@ -20,7 +20,7 @@ func TestGetWorkspaceAllowDenyListReadsViper(t *testing.T) {
 	viper.Set(config.KeyWorkspaceDenyList, "svc-c")
 	config.Reload()
 
-	allow, deny := getWorkspaceAllowDenyList()
+	allow, deny := getWorkspaceAllowDenyList(config.C)
 
 	wantAllow := []string{"zapier/svc-a", "org-b/svc-b"}
 	wantDeny := []string{"zapier/svc-c"}

--- a/pkg/tfc_trigger/workspace_allowdeny_list_test.go
+++ b/pkg/tfc_trigger/workspace_allowdeny_list_test.go
@@ -1,100 +1,32 @@
 package tfc_trigger
 
 import (
-	"os"
-	"strings"
+	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/spf13/viper"
+	"github.com/zapier/tfbuddy/internal/config"
 )
 
-func Test_isWorkspaceAllowed(t *testing.T) {
-	type args struct {
-		workspace string
-		org       string
-		allowList []string
-		denyList  []string
+func TestGetWorkspaceAllowDenyListReadsViper(t *testing.T) {
+	viper.Reset()
+	config.Init()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.Init()
+	})
+	viper.Set(config.KeyDefaultTFCOrganization, "zapier")
+	viper.Set(config.KeyWorkspaceAllowList, "svc-a, org-b/svc-b")
+	viper.Set(config.KeyWorkspaceDenyList, "svc-c")
+
+	allow, deny := getWorkspaceAllowDenyList()
+
+	wantAllow := []string{"zapier/svc-a", "org-b/svc-b"}
+	wantDeny := []string{"zapier/svc-c"}
+	if !reflect.DeepEqual(allow, wantAllow) {
+		t.Fatalf("allow = %v, want %v", allow, wantAllow)
 	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "ws-denied",
-			args: args{
-				workspace: "service-foo-prod",
-				allowList: []string{"service-foo-prod", "service-foo-staging"},
-				denyList:  []string{"service-foo-prod"},
-			},
-			want: false,
-		},
-		{
-			name: "ws-allowed",
-			args: args{
-				workspace: "service-foo-prod",
-				org:       "foocorp",
-				allowList: []string{"foocorp/service-foo-prod", "foocorp/service-foo-staging"},
-				denyList:  []string{"foocorp/service-foo-staging"},
-			},
-			want: true,
-		},
-		{
-			name: "ws-allowList-not-set",
-			args: args{
-				workspace: "service-foo-prod",
-				allowList: []string{},
-				denyList:  []string{},
-			},
-			want: true,
-		},
-		{
-			name: "ws-allowList-with-org",
-			args: args{
-				workspace: "service-foo-prod",
-				org:       "foo-org",
-				allowList: []string{"foo-org/service-foo-prod"},
-				denyList:  []string{},
-			},
-			want: true,
-		},
-		{
-			name: "ws-allowList-no-org",
-			args: args{
-				workspace: "service-foo-prod",
-				org:       "",
-				allowList: []string{"/service-foo-prod"},
-				denyList:  []string{},
-			},
-			want: true,
-		},
-		{
-			name: "ws-denied-by-omission",
-			args: args{
-				workspace: "service-foo-prod",
-				allowList: []string{"service-foo-staging"},
-				denyList:  []string{},
-			},
-			want: false,
-		},
-		{
-			name: "ws-denied-wrong-org",
-			args: args{
-				workspace: "acmecorp/service-foo-prod",
-				org:       "acmecorp",
-				allowList: []string{"foocorp/service-foo-prod"},
-				denyList:  []string{},
-			},
-			want: false,
-		},
-	}
-	defer os.Unsetenv("TFBUDDY_WORKSPACE_ALLOW_LIST")
-	defer os.Unsetenv("TFBUDDY_WORKSPACE_DENY_LIST")
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("TFBUDDY_WORKSPACE_ALLOW_LIST", strings.Join(tt.args.allowList, ","))
-			os.Setenv("TFBUDDY_WORKSPACE_DENY_LIST", strings.Join(tt.args.denyList, ","))
-			assert.Equalf(t, tt.want, isWorkspaceAllowed(tt.args.workspace, tt.args.org), "isWorkspaceAllowed(%v)", tt.args.workspace)
-		})
+	if !reflect.DeepEqual(deny, wantDeny) {
+		t.Fatalf("deny = %v, want %v", deny, wantDeny)
 	}
 }

--- a/pkg/tfc_utils/ci_job_run_status.go
+++ b/pkg/tfc_utils/ci_job_run_status.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/vcs/gitlab"
 	"go.opentelemetry.io/otel"
@@ -43,7 +44,12 @@ const MR_RUN_DETAILS_FORMAT = `
 `
 
 func MonitorRunStatus() {
-	glClient = gitlab.NewGitlabClient()
+	cfg, err := config.Load()
+	if err != nil {
+		log.Printf("error loading config: %v", err)
+		return
+	}
+	glClient = gitlab.NewGitlabClient(cfg)
 	tfcClient = tfc_api.NewTFCClient()
 	ctx := context.Background()
 

--- a/pkg/vcs/common.go
+++ b/pkg/vcs/common.go
@@ -2,8 +2,6 @@ package vcs
 
 import "github.com/zapier/tfbuddy/internal/config"
 
-const TF_BUDDY_AUTO_MERGE = "TFBUDDY_ALLOW_AUTO_MERGE"
-
 func IsGlobalAutoMergeEnabled(cfg config.Config) bool {
 	return cfg.AllowAutoMerge
 }

--- a/pkg/vcs/common.go
+++ b/pkg/vcs/common.go
@@ -1,10 +1,9 @@
 package vcs
 
-import "os"
+import "github.com/zapier/tfbuddy/internal/config"
 
 const TF_BUDDY_AUTO_MERGE = "TFBUDDY_ALLOW_AUTO_MERGE"
 
 func IsGlobalAutoMergeEnabled() bool {
-	//empty or true will permit auto merge.
-	return os.Getenv(TF_BUDDY_AUTO_MERGE) != "false"
+	return config.AutoMergeEnabled()
 }

--- a/pkg/vcs/common.go
+++ b/pkg/vcs/common.go
@@ -5,5 +5,5 @@ import "github.com/zapier/tfbuddy/internal/config"
 const TF_BUDDY_AUTO_MERGE = "TFBUDDY_ALLOW_AUTO_MERGE"
 
 func IsGlobalAutoMergeEnabled() bool {
-	return config.AutoMergeEnabled()
+	return config.C.AllowAutoMerge
 }

--- a/pkg/vcs/common.go
+++ b/pkg/vcs/common.go
@@ -4,6 +4,6 @@ import "github.com/zapier/tfbuddy/internal/config"
 
 const TF_BUDDY_AUTO_MERGE = "TFBUDDY_ALLOW_AUTO_MERGE"
 
-func IsGlobalAutoMergeEnabled() bool {
-	return config.C.AllowAutoMerge
+func IsGlobalAutoMergeEnabled(cfg config.Config) bool {
+	return cfg.AllowAutoMerge
 }

--- a/pkg/vcs/common_test.go
+++ b/pkg/vcs/common_test.go
@@ -17,7 +17,7 @@ func TestIsGlobalAutoMergeEnabledReadsViper(t *testing.T) {
 	viper.Set(config.KeyAllowAutoMerge, false)
 	config.Reload()
 
-	if IsGlobalAutoMergeEnabled() {
+	if IsGlobalAutoMergeEnabled(config.C) {
 		t.Fatal("IsGlobalAutoMergeEnabled() = true, want false")
 	}
 }

--- a/pkg/vcs/common_test.go
+++ b/pkg/vcs/common_test.go
@@ -1,0 +1,22 @@
+package vcs
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/zapier/tfbuddy/internal/config"
+)
+
+func TestIsGlobalAutoMergeEnabledReadsViper(t *testing.T) {
+	viper.Reset()
+	config.Init()
+	t.Cleanup(func() {
+		viper.Reset()
+		config.Init()
+	})
+	viper.Set(config.KeyAllowAutoMerge, false)
+
+	if IsGlobalAutoMergeEnabled() {
+		t.Fatal("IsGlobalAutoMergeEnabled() = true, want false")
+	}
+}

--- a/pkg/vcs/common_test.go
+++ b/pkg/vcs/common_test.go
@@ -15,6 +15,7 @@ func TestIsGlobalAutoMergeEnabledReadsViper(t *testing.T) {
 		config.Init()
 	})
 	viper.Set(config.KeyAllowAutoMerge, false)
+	config.Reload()
 
 	if IsGlobalAutoMergeEnabled() {
 		t.Fatal("IsGlobalAutoMergeEnabled() = true, want false")

--- a/pkg/vcs/github/cleanup_test.go
+++ b/pkg/vcs/github/cleanup_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	gogithub "github.com/google/go-github/v69/github"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/utils"
 )
 
@@ -91,6 +92,7 @@ func newGHTestClient(t *testing.T, serverURL string) *Client {
 
 func TestGH_GetOldRunUrls_SingleWorkspace_DeletesOlderPlan(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentID := int64(300)
 	comments := []fakeComment{
@@ -130,6 +132,7 @@ func TestGH_GetOldRunUrls_SingleWorkspace_DeletesOlderPlan(t *testing.T) {
 
 func TestGH_GetOldRunUrls_MultiWorkspace_KeepsOnePerWorkspaceAndAction(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentPlanA := int64(500)
 	comments := []fakeComment{
@@ -169,6 +172,7 @@ func TestGH_GetOldRunUrls_MultiWorkspace_KeepsOnePerWorkspaceAndAction(t *testin
 
 func TestGH_GetOldRunUrls_ApplyAction_OnlyDeletesMatchingApply(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentApplyA := int64(500)
 	comments := []fakeComment{
@@ -206,6 +210,7 @@ func TestGH_GetOldRunUrls_ApplyAction_OnlyDeletesMatchingApply(t *testing.T) {
 
 func TestGH_GetOldRunUrls_DeleteDisabled_NoDeletion(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "false")
+	config.Reload()
 
 	currentID := int64(200)
 	comments := []fakeComment{
@@ -237,6 +242,7 @@ func TestGH_GetOldRunUrls_DeleteDisabled_NoDeletion(t *testing.T) {
 
 func TestGH_GetOldRunUrls_FullMultiWorkspaceScenario(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentPlanA := int64(1000)
 	currentPlanB := int64(1100)

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -146,7 +146,7 @@ func (c *Client) GetOldRunUrls(ctx context.Context, prID int, fullName string, r
 		}
 	}
 
-	if config.DeleteOldCommentsEnabled() && len(matchingCommentIDs) > 0 {
+	if config.C.DeleteOldComments && len(matchingCommentIDs) > 0 {
 		for _, commentID := range matchingCommentIDs {
 			log.Debug().Str("workspace", workspace).Str("action", action).Msgf("Deleting comment %d", commentID)
 			if err := backoff.Retry(func() error {

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	client *gogithub.Client
 	ctx    context.Context
 	token  string
+	cfg    config.Config
 }
 
 const DefaultMaxRetries = 3
@@ -40,7 +41,7 @@ func createBackOffWithRetries() backoff.BackOff {
 	return backoff.WithMaxRetries(exp, DefaultMaxRetries)
 
 }
-func NewGithubClient() *Client {
+func NewGithubClient(cfg config.Config) *Client {
 	token := os.Getenv("GITHUB_TOKEN")
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
@@ -52,6 +53,7 @@ func NewGithubClient() *Client {
 		client: gogithub.NewClient(tc),
 		ctx:    ctx,
 		token:  token,
+		cfg:    cfg,
 	}
 }
 
@@ -146,7 +148,7 @@ func (c *Client) GetOldRunUrls(ctx context.Context, prID int, fullName string, r
 		}
 	}
 
-	if config.C.DeleteOldComments && len(matchingCommentIDs) > 0 {
+	if c.cfg.DeleteOldComments && len(matchingCommentIDs) > 0 {
 		for _, commentID := range matchingCommentIDs {
 			log.Debug().Str("workspace", workspace).Str("action", action).Msgf("Deleting comment %d", commentID)
 			if err := backoff.Retry(func() error {
@@ -286,7 +288,7 @@ func (c *Client) CloneMergeRequest(ctx context.Context, project string, mr vcs.M
 	if log.Trace().Enabled() {
 		progress = os.Stdout
 	}
-	cloneDepth := zgit.GetCloneDepth(GITHUB_CLONE_DEPTH_ENV)
+	cloneDepth := zgit.GetCloneDepth(c.cfg, GITHUB_CLONE_DEPTH_ENV)
 	gitRepo, err := git.PlainClone(dest, false, &git.CloneOptions{
 		Auth:          auth,
 		URL:           *repo.CloneURL,

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gogithub "github.com/google/go-github/v69/github"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	zgit "github.com/zapier/tfbuddy/pkg/git"
 	"github.com/zapier/tfbuddy/pkg/utils"
 	"github.com/zapier/tfbuddy/pkg/vcs"
@@ -105,8 +105,6 @@ func (c *Client) GetOldRunUrls(ctx context.Context, prID int, fullName string, r
 		return "", err
 	}
 
-	deleteOld, _ := strconv.ParseBool(os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS"))
-
 	var oldRunUrls []string
 	var oldRunBlock string
 	var matchingCommentIDs []int64
@@ -148,7 +146,7 @@ func (c *Client) GetOldRunUrls(ctx context.Context, prID int, fullName string, r
 		}
 	}
 
-	if deleteOld && len(matchingCommentIDs) > 0 {
+	if config.DeleteOldCommentsEnabled() && len(matchingCommentIDs) > 0 {
 		for _, commentID := range matchingCommentIDs {
 			log.Debug().Str("workspace", workspace).Str("action", action).Msgf("Deleting comment %d", commentID)
 			if err := backoff.Retry(func() error {

--- a/pkg/vcs/github/hooks/github_hooks_handler.go
+++ b/pkg/vcs/github/hooks/github_hooks_handler.go
@@ -54,7 +54,7 @@ func NewGithubHooksHandler(vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstrea
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 	}
 
-	ghEvents := githubevents.New(config.GithubHookSecretKey())
+	ghEvents := githubevents.New(config.C.GithubHookSecretKey)
 
 	// add Github event callbacks
 	ghEvents.OnIssueCommentCreated(h.handleIssueCommentCreatedEvent)

--- a/pkg/vcs/github/hooks/github_hooks_handler.go
+++ b/pkg/vcs/github/hooks/github_hooks_handler.go
@@ -21,13 +21,15 @@ import (
 )
 
 type TriggerCreationFunc func(
+	cfg config.Config,
 	vcs vcs.GitClient,
 	tfc tfc_api.ApiClient,
 	runstream runstream.StreamClient,
-	cfg *tfc_trigger.TFCTriggerOptions,
+	triggerCfg *tfc_trigger.TFCTriggerOptions,
 ) tfc_trigger.Trigger
 
 type GithubHooksHandler struct {
+	cfg             config.Config
 	tfc             tfc_api.ApiClient
 	vcs             vcs.GitClient
 	runstream       runstream.StreamClient
@@ -40,11 +42,12 @@ type GithubHooksHandler struct {
 	commentStream *gongs.GenericStream[GithubIssueCommentEventMsg, *GithubIssueCommentEventMsg]
 }
 
-func NewGithubHooksHandler(vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GithubHooksHandler {
+func NewGithubHooksHandler(cfg config.Config, vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GithubHooksHandler {
 	prStream := gongs.NewGenericStream[PullRequestEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(PullRequestEventType))
 	commentStream := gongs.NewGenericStream[GithubIssueCommentEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(IssueCommentEvent))
 
 	h := &GithubHooksHandler{
+		cfg:             cfg,
 		tfc:             tfc,
 		vcs:             vcs,
 		runstream:       rs,
@@ -54,7 +57,7 @@ func NewGithubHooksHandler(vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstrea
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 	}
 
-	ghEvents := githubevents.New(config.C.GithubHookSecretKey)
+	ghEvents := githubevents.New(cfg.GithubHookSecretKey)
 
 	// add Github event callbacks
 	ghEvents.OnIssueCommentCreated(h.handleIssueCommentCreatedEvent)

--- a/pkg/vcs/github/hooks/github_hooks_handler.go
+++ b/pkg/vcs/github/hooks/github_hooks_handler.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"context"
-	"os"
 
 	"github.com/cbrgm/githubevents/githubevents"
 	"github.com/google/go-github/v69/github"
@@ -11,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	"github.com/sl1pm4t/gongs"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/tfc_trigger"
@@ -41,7 +41,6 @@ type GithubHooksHandler struct {
 }
 
 func NewGithubHooksHandler(vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstream.StreamClient, js nats.JetStreamContext) *GithubHooksHandler {
-	hookSecretEnv := os.Getenv("TFBUDDY_GITHUB_HOOK_SECRET_KEY")
 	prStream := gongs.NewGenericStream[PullRequestEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(PullRequestEventType))
 	commentStream := gongs.NewGenericStream[GithubIssueCommentEventMsg](js, getGithubJetstreamName(), getGithubJetstreamSubject(IssueCommentEvent))
 
@@ -55,7 +54,7 @@ func NewGithubHooksHandler(vcs vcs.GitClient, tfc tfc_api.ApiClient, rs runstrea
 		triggerCreation: tfc_trigger.NewTFCTrigger,
 	}
 
-	ghEvents := githubevents.New(hookSecretEnv)
+	ghEvents := githubevents.New(config.GithubHookSecretKey())
 
 	// add Github event callbacks
 	ghEvents.OnIssueCommentCreated(h.handleIssueCommentCreatedEvent)

--- a/pkg/vcs/github/hooks/stream_worker.go
+++ b/pkg/vcs/github/hooks/stream_worker.go
@@ -44,7 +44,7 @@ func (h *GithubHooksHandler) processIssueComment(ctx context.Context, msg *Githu
 	// Check if fullName is allowed
 	log.Debug().Str("repo", *event.Repo.FullName).Msg("processIssueCommentEvent")
 	fullName := event.Repo.FullName
-	if !allow_list.IsGithubRepoAllowed(*fullName) {
+	if !allow_list.IsGithubRepoAllowed(h.cfg, *fullName) {
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func (h *GithubHooksHandler) processIssueComment(ctx context.Context, msg *Githu
 		return err
 	}
 
-	trigger := h.triggerCreation(h.vcs, h.tfc, h.runstream, cfg)
+	trigger := h.triggerCreation(h.cfg, h.vcs, h.tfc, h.runstream, cfg)
 
 	//// TODO: support additional commands and arguments (e.g. destroy, refresh, lock, unlock)
 	//// TODO: this should be refactored and be agnostic to the VCS type

--- a/pkg/vcs/github/run_events_worker.go
+++ b/pkg/vcs/github/run_events_worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/comment_formatter"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
@@ -16,14 +17,16 @@ import (
 const runEventsConsumerDurableName = "github"
 
 type RunEventsWorker struct {
+	cfg          config.Config
 	client       vcs.GitClient
 	rs           runstream.StreamClient
 	tfc          tfc_api.ApiClient
 	eventQCloser func()
 }
 
-func NewRunEventsWorker(client *Client, rs runstream.StreamClient, tfc tfc_api.ApiClient) *RunEventsWorker {
+func NewRunEventsWorker(cfg config.Config, client *Client, rs runstream.StreamClient, tfc tfc_api.ApiClient) *RunEventsWorker {
 	rsp := &RunEventsWorker{
+		cfg:    cfg,
 		client: client,
 		rs:     rs,
 		tfc:    tfc,
@@ -67,7 +70,7 @@ func (w *RunEventsWorker) postRunStatusComment(ctx context.Context, run *tfe.Run
 	ctx, span := otel.Tracer("TFC").Start(ctx, "postRunStatusComment")
 	defer span.End()
 
-	commentBody, topLevelNoteBody, _ := comment_formatter.FormatRunStatusCommentBody(w.tfc, run, rmd)
+	commentBody, topLevelNoteBody, _ := comment_formatter.FormatRunStatusCommentBody(w.cfg, w.tfc, run, rmd)
 
 	if topLevelNoteBody != "" {
 		if run.Status == tfe.RunErrored || run.Status == tfe.RunCanceled || run.Status == tfe.RunDiscarded || run.Status == tfe.RunPlannedAndFinished {

--- a/pkg/vcs/gitlab/cleanup_test.go
+++ b/pkg/vcs/gitlab/cleanup_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/utils"
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
@@ -18,7 +19,7 @@ import (
 const (
 	testProject = "test-group/test-project"
 	testMRIID   = 1
-	botUsername  = "tfbuddy-bot"
+	botUsername = "tfbuddy-bot"
 )
 
 type fakeNote struct {
@@ -113,6 +114,7 @@ func newTestClient(t *testing.T, serverURL string) *GitlabClient {
 
 func TestGetOldRunUrls_SingleWorkspace_DeletesOlderPlanKeepsNewest(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentNoteID := 300
 	discussions := []fakeDiscussion{
@@ -173,6 +175,7 @@ func TestGetOldRunUrls_SingleWorkspace_DeletesOlderPlanKeepsNewest(t *testing.T)
 
 func TestGetOldRunUrls_MultiWorkspace_KeepsOnePerWorkspaceAndAction(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentPlanA := 500
 	discussions := []fakeDiscussion{
@@ -253,6 +256,7 @@ func TestGetOldRunUrls_MultiWorkspace_KeepsOnePerWorkspaceAndAction(t *testing.T
 
 func TestGetOldRunUrls_ApplyAction_DeletesOlderApplyOnly(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentApplyA := 500
 	discussions := []fakeDiscussion{
@@ -322,6 +326,7 @@ func TestGetOldRunUrls_ApplyAction_DeletesOlderApplyOnly(t *testing.T) {
 
 func TestGetOldRunUrls_NoMatchingDiscussions_DeletesNothing(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentNoteID := 100
 	discussions := []fakeDiscussion{
@@ -361,6 +366,7 @@ func TestGetOldRunUrls_NoMatchingDiscussions_DeletesNothing(t *testing.T) {
 
 func TestGetOldRunUrls_DeleteDisabled_CollectsUrlsButNoDeletion(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "false")
+	config.Reload()
 
 	currentNoteID := 300
 	discussions := []fakeDiscussion{
@@ -404,6 +410,7 @@ func TestGetOldRunUrls_DeleteDisabled_CollectsUrlsButNoDeletion(t *testing.T) {
 
 func TestGetOldRunUrls_CollectsOldRunUrlsInTable(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentNoteID := 300
 	discussions := []fakeDiscussion{
@@ -446,6 +453,7 @@ func TestGetOldRunUrls_CollectsOldRunUrlsInTable(t *testing.T) {
 
 func TestGetOldRunUrls_MultiWorkspace_FullScenario(t *testing.T) {
 	t.Setenv("TFBUDDY_DELETE_OLD_COMMENTS", "true")
+	config.Reload()
 
 	currentPlanA := 1000
 	currentPlanB := 1100

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -24,6 +24,7 @@ type GitlabClient struct {
 	client    *gogitlab.Client
 	token     string
 	tokenUser string
+	cfg       config.Config
 }
 
 const DefaultMaxRetries = 3
@@ -34,7 +35,7 @@ func createBackOffWithRetries() backoff.BackOff {
 	return backoff.WithMaxRetries(exp, DefaultMaxRetries)
 
 }
-func NewGitlabClient() *GitlabClient {
+func NewGitlabClient(cfg config.Config) *GitlabClient {
 	token := os.Getenv("GITLAB_TOKEN")
 	if token == "" {
 		token = os.Getenv("GITLAB_ACCESS_TOKEN")
@@ -57,7 +58,7 @@ func NewGitlabClient() *GitlabClient {
 		log.Fatal().Msgf("Failed to create client: %v", err)
 	}
 
-	return &GitlabClient{glClient, token, tokenUser}
+	return &GitlabClient{client: glClient, token: token, tokenUser: tokenUser, cfg: cfg}
 }
 func (c *GitlabClient) ResolveMergeRequestDiscussion(ctx context.Context, projectWithNamespace string, mrIID int, discussionID string) error {
 	_, span := otel.Tracer("TFC").Start(ctx, "ResolveMergeRequestDiscussion")
@@ -220,7 +221,7 @@ func (c *GitlabClient) GetOldRunUrls(ctx context.Context, mrIID int, project str
 		toDelete = append(toDelete, discussionToDelete{noteIDs: noteIDs})
 	}
 
-	if config.C.DeleteOldComments {
+	if c.cfg.DeleteOldComments {
 		for _, d := range toDelete {
 			for _, noteID := range d.noteIDs {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Str("workspace", workspace).Str("action", action).Msgf("deleting note %d", noteID)

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/utils"
 	"github.com/zapier/tfbuddy/pkg/vcs"
 	"go.opentelemetry.io/otel"
@@ -160,8 +160,6 @@ func (c *GitlabClient) GetOldRunUrls(ctx context.Context, mrIID int, project str
 		return "", utils.CreatePermanentError(err)
 	}
 
-	deleteOld, _ := strconv.ParseBool(os.Getenv("TFBUDDY_DELETE_OLD_COMMENTS"))
-
 	var oldRunUrls []string
 	var oldRunBlock string
 
@@ -222,7 +220,7 @@ func (c *GitlabClient) GetOldRunUrls(ctx context.Context, mrIID int, project str
 		toDelete = append(toDelete, discussionToDelete{noteIDs: noteIDs})
 	}
 
-	if deleteOld {
+	if config.DeleteOldCommentsEnabled() {
 		for _, d := range toDelete {
 			for _, noteID := range d.noteIDs {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Str("workspace", workspace).Str("action", action).Msgf("deleting note %d", noteID)

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -220,7 +220,7 @@ func (c *GitlabClient) GetOldRunUrls(ctx context.Context, mrIID int, project str
 		toDelete = append(toDelete, discussionToDelete{noteIDs: noteIDs})
 	}
 
-	if config.DeleteOldCommentsEnabled() {
+	if config.C.DeleteOldComments {
 		for _, d := range toDelete {
 			for _, noteID := range d.noteIDs {
 				log.Debug().Str("projectID", project).Int("mrIID", mrIID).Str("workspace", workspace).Str("action", action).Msgf("deleting note %d", noteID)

--- a/pkg/vcs/gitlab/git_actions.go
+++ b/pkg/vcs/gitlab/git_actions.go
@@ -45,7 +45,7 @@ func (c *GitlabClient) CloneMergeRequest(ctx context.Context, project string, mr
 	if log.Trace().Enabled() {
 		progress = os.Stdout
 	}
-	cloneDepth := zgit.GetCloneDepth(GITLAB_CLONE_DEPTH_ENV)
+	cloneDepth := zgit.GetCloneDepth(c.cfg, GITLAB_CLONE_DEPTH_ENV)
 
 	repo, err := git.PlainClone(dest, false, &git.CloneOptions{
 		Auth:          auth,

--- a/pkg/vcs/gitlab/mr_comment_updater.go
+++ b/pkg/vcs/gitlab/mr_comment_updater.go
@@ -17,7 +17,7 @@ func (p *RunStatusUpdater) postRunStatusComment(ctx context.Context, run *tfe.Ru
 	ctx, span := otel.Tracer("TFC").Start(ctx, "postRunStatusComment")
 	defer span.End()
 
-	commentBody, topLevelNoteBody, resolveDiscussion := comment_formatter.FormatRunStatusCommentBody(p.tfc, run, rmd)
+	commentBody, topLevelNoteBody, resolveDiscussion := comment_formatter.FormatRunStatusCommentBody(p.cfg, p.tfc, run, rmd)
 
 	var oldUrls string
 	var err error

--- a/pkg/vcs/gitlab/mr_status_updater.go
+++ b/pkg/vcs/gitlab/mr_status_updater.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
-	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.opentelemetry.io/otel"
@@ -90,7 +89,7 @@ func (p *RunStatusUpdater) updateCommitStatusForRun(ctx context.Context, run *tf
 		// A sentinel policy has soft failed for a plan-only run. This is a final state.
 		// During the apply, the policy failure will need to be overriden.
 		log.Debug().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		if config.C.FailCIOnSentinelSoftFail && rmd.GetAction() == runstream.PlanAction {
+		if p.cfg.FailCIOnSentinelSoftFail && rmd.GetAction() == runstream.PlanAction {
 			p.updateStatus(ctx, gogitlab.Failed, "plan", rmd)
 		} else {
 			p.updateStatus(ctx, gogitlab.Success, rmd.GetAction(), rmd)

--- a/pkg/vcs/gitlab/mr_status_updater.go
+++ b/pkg/vcs/gitlab/mr_status_updater.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.opentelemetry.io/otel"
@@ -91,13 +90,7 @@ func (p *RunStatusUpdater) updateCommitStatusForRun(ctx context.Context, run *tf
 		// A sentinel policy has soft failed for a plan-only run. This is a final state.
 		// During the apply, the policy failure will need to be overriden.
 		log.Debug().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		failOnSoftEnv := os.Getenv("TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL")
-		failOnSoft, err := strconv.ParseBool(failOnSoftEnv)
-		if err != nil {
-			log.Error().Err(err).Str("env_var", "TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL").Msg("could not parse env var, defaulting to false")
-			failOnSoft = false
-		}
-		if failOnSoft && rmd.GetAction() == runstream.PlanAction {
+		if config.FailCIOnSentinelSoftFail() && rmd.GetAction() == runstream.PlanAction {
 			p.updateStatus(ctx, gogitlab.Failed, "plan", rmd)
 		} else {
 			p.updateStatus(ctx, gogitlab.Success, rmd.GetAction(), rmd)

--- a/pkg/vcs/gitlab/mr_status_updater.go
+++ b/pkg/vcs/gitlab/mr_status_updater.go
@@ -90,7 +90,7 @@ func (p *RunStatusUpdater) updateCommitStatusForRun(ctx context.Context, run *tf
 		// A sentinel policy has soft failed for a plan-only run. This is a final state.
 		// During the apply, the policy failure will need to be overriden.
 		log.Debug().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("policy soft failed")
-		if config.FailCIOnSentinelSoftFail() && rmd.GetAction() == runstream.PlanAction {
+		if config.C.FailCIOnSentinelSoftFail && rmd.GetAction() == runstream.PlanAction {
 			p.updateStatus(ctx, gogitlab.Failed, "plan", rmd)
 		} else {
 			p.updateStatus(ctx, gogitlab.Success, rmd.GetAction(), rmd)

--- a/pkg/vcs/gitlab/mr_status_updater_test.go
+++ b/pkg/vcs/gitlab/mr_status_updater_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/mocks"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/vcs"
@@ -131,6 +132,7 @@ func TestAutoMergeTargetedApply(t *testing.T) {
 
 func TestPolicySoftFailPlanFailsPipelineWhenEnvTrue(t *testing.T) {
 	t.Setenv("TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL", "true")
+	config.Reload()
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -170,4 +172,5 @@ func TestPolicySoftFailPlanFailsPipelineWhenEnvTrue(t *testing.T) {
 
 	// Clean up env var for safety (though t.Setenv handles this)
 	os.Unsetenv("TFBUDDY_FAIL_CI_ON_SENTINEL_SOFT_FAIL")
+	config.Reload()
 }

--- a/pkg/vcs/gitlab/run_status_updater.go
+++ b/pkg/vcs/gitlab/run_status_updater.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"github.com/hashicorp/go-tfe"
 	"github.com/rs/zerolog/log"
+	"github.com/zapier/tfbuddy/internal/config"
 	"github.com/zapier/tfbuddy/pkg/runstream"
 	"github.com/zapier/tfbuddy/pkg/tfc_api"
 	"github.com/zapier/tfbuddy/pkg/vcs"
@@ -10,14 +11,16 @@ import (
 )
 
 type RunStatusUpdater struct {
+	cfg          config.Config
 	client       vcs.GitClient
 	rs           runstream.StreamClient
 	tfc          tfc_api.ApiClient
 	eventQCloser func()
 }
 
-func NewRunStatusProcessor(client *GitlabClient, rs runstream.StreamClient, tfc tfc_api.ApiClient) *RunStatusUpdater {
+func NewRunStatusProcessor(cfg config.Config, client *GitlabClient, rs runstream.StreamClient, tfc tfc_api.ApiClient) *RunStatusUpdater {
 	rsp := &RunStatusUpdater{
+		cfg:    cfg,
 		client: client,
 		rs:     rs,
 		tfc:    tfc,


### PR DESCRIPTION
## Summary
- add a Viper-backed internal config layer for TFBuddy-owned settings
- replace manual owned env reads across logging, hooks, trigger config, comment behavior, NATS, and clone depth handling
- add regression tests proving repo-owned config can be driven through Viper

## Testing
- go test ./...
