### PR TITLE
fix: attach pipeline ID to GitLab commit status updates

### DIFF
--- a/pkg/vcs/gitlab/mr_status_updater.go
+++ b/pkg/vcs/gitlab/mr_status_updater.go
@@ -124,7 +124,7 @@ func (p *RunStatusUpdater) updateStatus(ctx context.Context, state gogitlab.Buil
 	var pipelineID *int
 	getPipelineIDFn := func() error {
 		log.Debug().Str("project", rmd.GetMRProjectNameWithNamespace()).Int("mergeRequestID", rmd.GetMRInternalID()).Msg("getting pipeline status")
-		pipelineID := p.getLatestPipelineID(ctx, rmd)
+		pipelineID = p.getLatestPipelineID(ctx, rmd)
 		if pipelineID == nil {
 			return errNoPipelineStatus
 		}

--- a/pkg/vcs/gitlab/mr_status_updater_test.go
+++ b/pkg/vcs/gitlab/mr_status_updater_test.go
@@ -31,6 +31,67 @@ func (m *commitStatusStateMatcher) String() string {
 	return "matches commit status with state=" + m.expectedState
 }
 
+// pipelineIDMatcher asserts that the commit status options carry the expected pipeline ID.
+type pipelineIDMatcher struct {
+	expectedID int
+}
+
+func (m *pipelineIDMatcher) Matches(x interface{}) bool {
+	opts, ok := x.(*GitlabCommitStatusOptions)
+	if !ok {
+		return false
+	}
+	if opts.PipelineID == nil {
+		return false
+	}
+	return *opts.PipelineID == m.expectedID
+}
+
+func (m *pipelineIDMatcher) String() string {
+	return "matches commit status whose PipelineID is set to the expected value"
+}
+
+// TestUpdateStatusAttachesPipelineID guards against a regression of the closure
+// shadowing bug where the resolved pipeline ID was discarded and SetCommitStatus
+// was called with PipelineID == nil. Without an attached pipeline ID, GitLab
+// can't associate the status with the current MR pipeline, leaving the "apply"
+// check stuck and pipeline-status links pointing at stale runs.
+func TestUpdateStatusAttachesPipelineID(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{}, t)
+
+	const expectedPipelineID = 42
+	testSuite.MockGitClient.EXPECT().
+		GetPipelinesForCommit(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]vcs.ProjectPipeline{&GitlabPipeline{&gogitlab.PipelineInfo{ID: expectedPipelineID, Source: "merge_request_event"}}}, nil).
+		AnyTimes()
+
+	testSuite.MockGitClient.EXPECT().
+		SetCommitStatus(
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+			&pipelineIDMatcher{expectedID: expectedPipelineID},
+		).
+		Return(&GitlabCommitStatus{&gogitlab.CommitStatus{}}, nil).
+		Times(1)
+
+	testSuite.InitTestSuite()
+	r := &RunStatusUpdater{
+		cfg:    config.C,
+		tfc:    testSuite.MockApiClient,
+		client: testSuite.MockGitClient,
+		rs:     testSuite.MockStreamClient,
+	}
+
+	r.updateStatus(context.Background(), gogitlab.Success, "apply", &runstream.TFRunMetadata{
+		Action:    "apply",
+		Workspace: "service-tfbuddy",
+		RunID:     "run-123",
+	})
+}
+
 func TestAutoMergeNoChangesApply(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary

- The closure in `updateStatus` (`pkg/vcs/gitlab/mr_status_updater.go`) used `:=` to assign the resolved pipeline ID, shadowing the outer `pipelineID` variable. The outer variable stayed `nil`, so `status.PipelineID` was never set and every `SetCommitStatus` call went to GitLab without a pipeline association.
- Without an attached pipeline ID, GitLab can't bind the status to the current MR pipeline. This produced two visible symptoms reported in the field:
  1. After a no-change plan/apply, the `TFC/apply/<workspace>` check stays stuck "waiting" — the `Success` update from `RunPlannedAndFinished` lands on the wrong (or no) pipeline.
  2. The pipeline-status link on commit statuses points at stale runs instead of the most recent plan/apply, for the same reason.
- Fix is a one-character change (`:=` → `=`) so the closure writes through to the outer variable. Added a regression test (`TestUpdateStatusAttachesPipelineID`) that asserts `SetCommitStatus` is called with a non-nil `PipelineID` matching the resolved pipeline. Go's nilness checker also flagged the original code with `impossible condition: nil != nil` on the `if pipelineID != nil` guard, which confirms the shadowing.

## Test plan

- [x] `go test ./pkg/vcs/gitlab/... -run TestUpdateStatusAttachesPipelineID -v` — new test fails before fix, passes after
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [ ] Manual: verify on a real GitLab MR that a no-change `tfc apply` flips the `TFC/apply/<ws>` check to success and that the pipeline link on the commit status opens the current pipeline