### PR TITLE
fix: dedupe TFC run-event publishes and mark locked-workspace errors

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,7 @@ The full list of supported environment variables and flags is described below:
 |`TFBUDDY_WORKSPACE_JETSTREAM_REPLICAS`|`--workspace-jetstream-replicas`|JetStream replica count for the workspace-trigger stream. Use 1 for single-node NATS or local dev; set to your NATS cluster size (often 3) in production for durability.|`1`|
 |`TFBUDDY_TFC_RATE_LIMIT_RPS`|`--tfc-rate-limit-rps`|Client-side rate limit (requests per second) for the Terraform Cloud API. Tuned to match TFC's documented per-token limit and prevent 429s when many workspaces are triggered concurrently.|`30`|
 |`TFBUDDY_TFC_RATE_LIMIT_BURST`|`--tfc-rate-limit-burst`|Burst capacity for the TFC API token-bucket rate limiter.|`30`|
+|`TFBUDDY_JETSTREAM_DEDUP_WINDOW`|`--jetstream-dedup-window`|Window during which JetStream remembers a Nats-Msg-Id to dedupe republishes. Applied to RUN_EVENTS and TFBUDDY_WORKSPACE_TRIGGERS streams. Accepts a Go duration string (e.g. 30m, 1h).|`30m0s`|
 <!-- END GENERATED CONFIGURATION -->
 
 For sensitive environment variables use `secrets.envs` which can contain a list of key/value pairs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/pflag"
@@ -34,6 +35,7 @@ const (
 	KeyWorkspaceJetStreamReplicas = "workspace-jetstream-replicas"
 	KeyTFCRateLimitRPS            = "tfc-rate-limit-rps"
 	KeyTFCRateLimitBurst          = "tfc-rate-limit-burst"
+	KeyJetStreamDedupWindow       = "jetstream-dedup-window"
 )
 
 type Config struct {
@@ -58,8 +60,9 @@ type Config struct {
 	GitlabCloneDepth           int      `mapstructure:"gitlab-clone-depth"`
 	WorkspaceFanoutEnabled     bool     `mapstructure:"workspace-fanout-enabled"`
 	WorkspaceJetStreamReplicas int      `mapstructure:"workspace-jetstream-replicas"`
-	TFCRateLimitRPS            int      `mapstructure:"tfc-rate-limit-rps"`
-	TFCRateLimitBurst          int      `mapstructure:"tfc-rate-limit-burst"`
+	TFCRateLimitRPS            int           `mapstructure:"tfc-rate-limit-rps"`
+	TFCRateLimitBurst          int           `mapstructure:"tfc-rate-limit-burst"`
+	JetStreamDedupWindow       time.Duration `mapstructure:"jetstream-dedup-window"`
 }
 
 var C Config
@@ -95,6 +98,13 @@ var bindings = []binding{
 	{key: KeyWorkspaceJetStreamReplicas, defaultValue: 1, description: "JetStream replica count for the workspace-trigger stream. Use 1 for single-node NATS or local dev; set to your NATS cluster size (often 3) in production for durability."},
 	{key: KeyTFCRateLimitRPS, defaultValue: 30, description: "Client-side rate limit (requests per second) for the Terraform Cloud API. Tuned to match TFC's documented per-token limit and prevent 429s when many workspaces are triggered concurrently."},
 	{key: KeyTFCRateLimitBurst, defaultValue: 30, description: "Burst capacity for the TFC API token-bucket rate limiter."},
+	// Dedup window for NATS JetStream-backed streams that use Nats-Msg-Id. Applied
+	// to RUN_EVENTS (TFC notification publishes, dedup key runID:status) and
+	// TFBUDDY_WORKSPACE_TRIGGERS (per-workspace MR fan-out, dedup key
+	// deliveryID/workspace/org). Long enough to cover the slowest plausible same-key
+	// re-fire (e.g. TFC firing multiple notification triggers across a long
+	// planning phase), short enough that JetStream's interest store stays bounded.
+	{key: KeyJetStreamDedupWindow, defaultValue: 30 * time.Minute, description: "Window during which JetStream remembers a Nats-Msg-Id to dedupe republishes. Applied to RUN_EVENTS and TFBUDDY_WORKSPACE_TRIGGERS streams. Accepts a Go duration string (e.g. 30m, 1h)."},
 }
 
 func init() {
@@ -152,6 +162,8 @@ func RegisterFlags(fs *pflag.FlagSet) error {
 			fs.Int(item.key, def, item.description)
 		case []string:
 			fs.StringSlice(item.key, def, item.description)
+		case time.Duration:
+			fs.Duration(item.key, def, item.description)
 		default:
 			continue
 		}
@@ -261,6 +273,8 @@ func defaultValueString(value any) string {
 			return ""
 		}
 		return strings.Join(v, ",")
+	case time.Duration:
+		return v.String()
 	default:
 		return ""
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -76,6 +77,23 @@ func TestDevModeDefaultsToFalse(t *testing.T) {
 
 	if C.DevMode {
 		t.Fatal("C.DevMode = true, want false")
+	}
+}
+
+func TestJetStreamDedupWindowDefaultsTo30Minutes(t *testing.T) {
+	resetViperForTest(t)
+
+	if got, want := C.JetStreamDedupWindow, 30*time.Minute; got != want {
+		t.Fatalf("C.JetStreamDedupWindow = %s, want %s", got, want)
+	}
+}
+
+func TestJetStreamDedupWindowCanBeSetFromEnv(t *testing.T) {
+	t.Setenv("TFBUDDY_JETSTREAM_DEDUP_WINDOW", "5m")
+	resetViperForTest(t)
+
+	if got, want := C.JetStreamDedupWindow, 5*time.Minute; got != want {
+		t.Fatalf("C.JetStreamDedupWindow = %s, want %s", got, want)
 	}
 }
 

--- a/pkg/hooks/server.go
+++ b/pkg/hooks/server.go
@@ -46,7 +46,7 @@ func StartServer(cfg config.Config) {
 	}
 
 	hs := hooks_stream.NewHooksStream(nc)
-	rs := runstream.NewStream(js)
+	rs := runstream.NewStream(js, cfg.JetStreamDedupWindow)
 	health.AddReadinessCheck("nats-connection", tfnats.HealthcheckFn(nc))
 	health.AddLivenessCheck("nats-connection", tfnats.HealthcheckFn(nc))
 	health.AddLivenessCheck("runstream-streams", rs.HealthCheck)
@@ -61,7 +61,7 @@ func StartServer(cfg config.Config) {
 	// legacy inline path during rollout.
 	var workspaceStream tfc_trigger.WorkspacePublisher
 	if cfg.WorkspaceFanoutEnabled {
-		ws, err := tfc_trigger.NewWorkspaceStream(js, cfg.WorkspaceJetStreamReplicas)
+		ws, err := tfc_trigger.NewWorkspaceStream(js, cfg.WorkspaceJetStreamReplicas, cfg.JetStreamDedupWindow)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not configure workspace trigger stream")
 		}

--- a/pkg/runstream/run_event.go
+++ b/pkg/runstream/run_event.go
@@ -84,8 +84,9 @@ func (s *Stream) PublishTFRunEvent(ctx context.Context, re RunEvent) error {
 	return err
 }
 
-// tfRunEventMsgID is the JetStream dedup key for a TFRunEvent. Exported as a
-// helper so tests and other publishers (e.g. polling) can compute the same key.
+// tfRunEventMsgID is the JetStream dedup key for a TFRunEvent. Package-level
+// helper so the publish path and the in-package tests stay in lockstep — keep
+// it unexported until another package actually needs to compute the same key.
 func tfRunEventMsgID(runID, newStatus string) string {
 	return runID + ":" + newStatus
 }
@@ -153,13 +154,11 @@ func (s *Stream) SubscribeTFRunEvents(vcsProvider string, cb func(run RunEvent) 
 	return closer, nil
 }
 
-// tfRunEventDuplicatesWindow caps how long JetStream remembers a Nats-Msg-Id
-// for dedup. Set to 30 minutes: longer than the worst-case time a single TFC
-// run dwells in one logical status (typical apply finishes in well under 10
-// minutes; bumped to 30m for slow workspaces and long-running policy checks).
-const tfRunEventDuplicatesWindow = 30 * time.Minute
-
-func configureTFRunEventsStream(js nats.JetStreamContext) {
+// configureTFRunEventsStream provisions the RUN_EVENTS stream. dedupWindow
+// sets the JetStream Duplicates window used in tandem with the Nats-Msg-Id
+// stamped by PublishTFRunEvent. Operators tune the window via the
+// TFBUDDY_JETSTREAM_DEDUP_WINDOW env var; tests pass an explicit value.
+func configureTFRunEventsStream(js nats.JetStreamContext, dedupWindow time.Duration) {
 	sCfg := &nats.StreamConfig{
 		Name:        RunEventsStreamName,
 		Description: "Terraform Cloud Run Notifications",
@@ -168,7 +167,7 @@ func configureTFRunEventsStream(js nats.JetStreamContext) {
 		MaxMsgs:     10240,
 		MaxAge:      time.Hour * 6,
 		Replicas:    1,
-		Duplicates:  tfRunEventDuplicatesWindow,
+		Duplicates:  dedupWindow,
 	}
 
 	addOrUpdateStream(js, sCfg)

--- a/pkg/runstream/run_event.go
+++ b/pkg/runstream/run_event.go
@@ -64,9 +64,30 @@ func (s *Stream) PublishTFRunEvent(ctx context.Context, re RunEvent) error {
 	if err != nil {
 		return err
 	}
-	_, err = s.js.Publish(fmt.Sprintf("%s.%s", RunEventsStreamName, rmd.GetVcsProvider()), b)
+
+	// Anchor JetStream dedup to (runID, newStatus). TFC fires a webhook for
+	// every configured notification trigger, and several triggers resolve to
+	// the same RunStatus over the run's lifecycle (e.g. plan_queued, planning,
+	// cost_estimating, policy_checking can all surface as `planning` in the
+	// notification payload). Without this header, each redundant webhook
+	// produced its own TFRunEvent and a duplicate GitLab reply.
+	// Combined with the Duplicates window on the stream (see
+	// configureTFRunEventsStream), this collapses retries and same-status
+	// redeliveries server-side.
+	msgID := tfRunEventMsgID(re.GetRunID(), re.GetNewStatus())
+	_, err = s.js.Publish(
+		fmt.Sprintf("%s.%s", RunEventsStreamName, rmd.GetVcsProvider()),
+		b,
+		nats.MsgId(msgID),
+	)
 
 	return err
+}
+
+// tfRunEventMsgID is the JetStream dedup key for a TFRunEvent. Exported as a
+// helper so tests and other publishers (e.g. polling) can compute the same key.
+func tfRunEventMsgID(runID, newStatus string) string {
+	return runID + ":" + newStatus
 }
 
 func (s *Stream) SubscribeTFRunEvents(vcsProvider string, cb func(run RunEvent) bool) (closer func(), err error) {
@@ -132,6 +153,12 @@ func (s *Stream) SubscribeTFRunEvents(vcsProvider string, cb func(run RunEvent) 
 	return closer, nil
 }
 
+// tfRunEventDuplicatesWindow caps how long JetStream remembers a Nats-Msg-Id
+// for dedup. Set to 30 minutes: longer than the worst-case time a single TFC
+// run dwells in one logical status (typical apply finishes in well under 10
+// minutes; bumped to 30m for slow workspaces and long-running policy checks).
+const tfRunEventDuplicatesWindow = 30 * time.Minute
+
 func configureTFRunEventsStream(js nats.JetStreamContext) {
 	sCfg := &nats.StreamConfig{
 		Name:        RunEventsStreamName,
@@ -141,6 +168,7 @@ func configureTFRunEventsStream(js nats.JetStreamContext) {
 		MaxMsgs:     10240,
 		MaxAge:      time.Hour * 6,
 		Replicas:    1,
+		Duplicates:  tfRunEventDuplicatesWindow,
 	}
 
 	addOrUpdateStream(js, sCfg)

--- a/pkg/runstream/run_event_dedup_test.go
+++ b/pkg/runstream/run_event_dedup_test.go
@@ -2,7 +2,6 @@ package runstream
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -15,11 +14,8 @@ import (
 // comments — TFC fires a webhook for every notification trigger, and several
 // triggers can resolve to the same RunStatus over the run's lifecycle.
 func Test_PublishTFRunEvent_DedupesSameRunIDAndStatus(t *testing.T) {
-	const port = 8371
-	srv := RunServerOnPort(port)
-	defer srv.Shutdown()
-
-	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	_, url := startTestNATS(t)
+	nc := testConnect(t, url)
 	defer nc.Close()
 	js := testGetJetstreamContext(t, nc)
 
@@ -41,11 +37,8 @@ func Test_PublishTFRunEvent_DedupesSameRunIDAndStatus(t *testing.T) {
 // must all land on the stream — that's how real state transitions reach the
 // GitLab reply pipeline.
 func Test_PublishTFRunEvent_KeepsDistinctStatuses(t *testing.T) {
-	const port = 8372
-	srv := RunServerOnPort(port)
-	defer srv.Shutdown()
-
-	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	_, url := startTestNATS(t)
+	nc := testConnect(t, url)
 	defer nc.Close()
 	js := testGetJetstreamContext(t, nc)
 
@@ -65,11 +58,8 @@ func Test_PublishTFRunEvent_KeepsDistinctStatuses(t *testing.T) {
 // Test_PublishTFRunEvent_DedupesAcrossRuns verifies that the dedup is keyed
 // to runID so different runs at the same status are not collapsed.
 func Test_PublishTFRunEvent_DedupesAcrossRuns(t *testing.T) {
-	const port = 8373
-	srv := RunServerOnPort(port)
-	defer srv.Shutdown()
-
-	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	_, url := startTestNATS(t)
+	nc := testConnect(t, url)
 	defer nc.Close()
 	js := testGetJetstreamContext(t, nc)
 
@@ -94,11 +84,8 @@ func Test_PublishTFRunEvent_DedupesAcrossRuns(t *testing.T) {
 // status transitions before the apply run progresses to applying -> applied.
 // Each run must own its own set of dedup messages — none collide.
 func Test_PublishTFRunEvent_PlanThenApplyFlow(t *testing.T) {
-	const port = 8374
-	srv := RunServerOnPort(port)
-	defer srv.Shutdown()
-
-	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	_, url := startTestNATS(t)
+	nc := testConnect(t, url)
 	defer nc.Close()
 	js := testGetJetstreamContext(t, nc)
 
@@ -158,7 +145,7 @@ func Test_tfRunEventMsgID(t *testing.T) {
 // it on entry so each test starts at zero messages and zero dedup history.
 func newTestStream(t *testing.T, js nats.JetStreamContext) *Stream {
 	t.Helper()
-	configureTFRunEventsStream(js)
+	configureTFRunEventsStream(js, testDedupWindow)
 	if err := js.PurgeStream(RunEventsStreamName); err != nil {
 		t.Fatalf("could not purge %s before test: %v", RunEventsStreamName, err)
 	}

--- a/pkg/runstream/run_event_dedup_test.go
+++ b/pkg/runstream/run_event_dedup_test.go
@@ -1,0 +1,215 @@
+package runstream
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// Test_PublishTFRunEvent_DedupesSameRunIDAndStatus verifies that two
+// publishes for the same (runID, newStatus) result in a single message on
+// the RUN_EVENTS stream. This is the core fix for duplicate GitLab reply
+// comments — TFC fires a webhook for every notification trigger, and several
+// triggers can resolve to the same RunStatus over the run's lifecycle.
+func Test_PublishTFRunEvent_DedupesSameRunIDAndStatus(t *testing.T) {
+	const port = 8371
+	srv := RunServerOnPort(port)
+	defer srv.Shutdown()
+
+	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	defer nc.Close()
+	js := testGetJetstreamContext(t, nc)
+
+	s := newTestStream(t, js)
+	seedRunMetadata(t, s, "run-DEDUP", "gitlab")
+
+	publishOnce(t, s, "run-DEDUP", "planning")
+	publishOnce(t, s, "run-DEDUP", "planning")
+	publishOnce(t, s, "run-DEDUP", "planning")
+
+	if got := streamMsgs(t, js); got != 1 {
+		t.Fatalf("expected 1 message on %s after 3 same-status publishes, got %d",
+			RunEventsStreamName, got)
+	}
+}
+
+// Test_PublishTFRunEvent_KeepsDistinctStatuses verifies that the dedup is
+// scoped to (runID, newStatus). Different status values for the same run
+// must all land on the stream — that's how real state transitions reach the
+// GitLab reply pipeline.
+func Test_PublishTFRunEvent_KeepsDistinctStatuses(t *testing.T) {
+	const port = 8372
+	srv := RunServerOnPort(port)
+	defer srv.Shutdown()
+
+	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	defer nc.Close()
+	js := testGetJetstreamContext(t, nc)
+
+	s := newTestStream(t, js)
+	seedRunMetadata(t, s, "run-DISTINCT", "gitlab")
+
+	for _, status := range []string{"planning", "planned", "applying", "applied"} {
+		publishOnce(t, s, "run-DISTINCT", status)
+	}
+
+	if got := streamMsgs(t, js); got != 4 {
+		t.Fatalf("expected 4 messages on %s for 4 distinct statuses, got %d",
+			RunEventsStreamName, got)
+	}
+}
+
+// Test_PublishTFRunEvent_DedupesAcrossRuns verifies that the dedup is keyed
+// to runID so different runs at the same status are not collapsed.
+func Test_PublishTFRunEvent_DedupesAcrossRuns(t *testing.T) {
+	const port = 8373
+	srv := RunServerOnPort(port)
+	defer srv.Shutdown()
+
+	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	defer nc.Close()
+	js := testGetJetstreamContext(t, nc)
+
+	s := newTestStream(t, js)
+	seedRunMetadata(t, s, "run-A", "gitlab")
+	seedRunMetadata(t, s, "run-B", "gitlab")
+
+	publishOnce(t, s, "run-A", "planning")
+	publishOnce(t, s, "run-A", "planning") // dedup
+	publishOnce(t, s, "run-B", "planning") // distinct run, must land
+	publishOnce(t, s, "run-B", "planning") // dedup
+
+	if got := streamMsgs(t, js); got != 2 {
+		t.Fatalf("expected 2 messages (one per runID) on %s, got %d",
+			RunEventsStreamName, got)
+	}
+}
+
+// Test_PublishTFRunEvent_PlanThenApplyFlow simulates the manual
+// plan-then-`tfc apply` workflow. Plan and apply are two separate TFC runs
+// with distinct runIDs, but both pass through the planning -> planned
+// status transitions before the apply run progresses to applying -> applied.
+// Each run must own its own set of dedup messages — none collide.
+func Test_PublishTFRunEvent_PlanThenApplyFlow(t *testing.T) {
+	const port = 8374
+	srv := RunServerOnPort(port)
+	defer srv.Shutdown()
+
+	nc := testConnect(t, fmt.Sprintf("nats://127.0.0.1:%d", port))
+	defer nc.Close()
+	js := testGetJetstreamContext(t, nc)
+
+	s := newTestStream(t, js)
+	seedRunMetadata(t, s, "run-PLAN", "gitlab")
+	seedRunMetadata(t, s, "run-APPLY", "gitlab")
+
+	// Plan run: TFC walks pending -> planning -> planned -> planned_and_finished.
+	// Each redundant webhook within a status (e.g. plan_queued + planning
+	// both surface as `planning`) is collapsed by dedup.
+	planStatuses := []string{"pending", "planning", "planning", "planned", "planned_and_finished"}
+	for _, status := range planStatuses {
+		publishOnce(t, s, "run-PLAN", status)
+	}
+
+	// Apply run: separate runID. TFC runs always plan first, so this run
+	// also passes through `planning` and `planned` before reaching the apply
+	// phase. Same status names, different runID = distinct dedup keys.
+	applyStatuses := []string{"pending", "planning", "planned", "applying", "applying", "applied", "applied"}
+	for _, status := range applyStatuses {
+		publishOnce(t, s, "run-APPLY", status)
+	}
+
+	// Expected unique (runID, status) pairs:
+	//   run-PLAN:  pending, planning, planned, planned_and_finished   (4)
+	//   run-APPLY: pending, planning, planned, applying, applied      (5)
+	const want = 9
+	if got := streamMsgs(t, js); got != want {
+		t.Fatalf("plan+apply flow: expected %d distinct messages, got %d", want, got)
+	}
+}
+
+// Test_tfRunEventMsgID locks in the exact dedup-key shape so a refactor
+// can't accidentally widen or narrow the scope.
+func Test_tfRunEventMsgID(t *testing.T) {
+	tests := []struct {
+		runID, status, want string
+	}{
+		{"run-rKys4r9a19W7Dk8Q", "planning", "run-rKys4r9a19W7Dk8Q:planning"},
+		{"run-rKys4r9a19W7Dk8Q", "applied", "run-rKys4r9a19W7Dk8Q:applied"},
+		{"run-OTHER", "planning", "run-OTHER:planning"},
+	}
+	for _, tc := range tests {
+		if got := tfRunEventMsgID(tc.runID, tc.status); got != tc.want {
+			t.Errorf("tfRunEventMsgID(%q, %q) = %q, want %q",
+				tc.runID, tc.status, got, tc.want)
+		}
+	}
+}
+
+// newTestStream wires up a Stream wired to the test JetStream context. We
+// skip NewStream() because it spins up a polling task dispatcher goroutine
+// that we don't need for these tests.
+//
+// JetStream uses on-disk storage by default and natstest reuses os.TempDir()
+// across instances, so the stream can survive a NATS server shutdown. Purge
+// it on entry so each test starts at zero messages and zero dedup history.
+func newTestStream(t *testing.T, js nats.JetStreamContext) *Stream {
+	t.Helper()
+	configureTFRunEventsStream(js)
+	if err := js.PurgeStream(RunEventsStreamName); err != nil {
+		t.Fatalf("could not purge %s before test: %v", RunEventsStreamName, err)
+	}
+	kv, err := configureTFRunMetadataKVStore(js)
+	if err != nil {
+		t.Fatalf("could not configure metadata KV: %v", err)
+	}
+	return &Stream{js: js, metadataKV: kv}
+}
+
+func seedRunMetadata(t *testing.T, s *Stream, runID, vcs string) {
+	t.Helper()
+	// KV is persistent across test runs (file storage under os.TempDir).
+	// Clear any prior entry so AddRunMeta's Create() doesn't fail with
+	// "key exists" when tests are re-run.
+	_ = s.metadataKV.Delete(runID)
+	rmd := &TFRunMetadata{
+		RunID:                                runID,
+		Organization:                         "zapier",
+		Workspace:                            "test-ws",
+		Action:                               "plan",
+		CommitSHA:                            "deadbeef",
+		MergeRequestProjectNameWithNamespace: "zapier/terraform-services",
+		MergeRequestIID:                      1,
+		VcsProvider:                          vcs,
+	}
+	if err := s.AddRunMeta(rmd); err != nil {
+		t.Fatalf("could not seed RunMetadata for %q: %v", runID, err)
+	}
+}
+
+func publishOnce(t *testing.T, s *Stream, runID, status string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	re := &TFRunEvent{
+		RunID:        runID,
+		Organization: "zapier",
+		Workspace:    "test-ws",
+		NewStatus:    status,
+	}
+	if err := s.PublishTFRunEvent(ctx, re); err != nil {
+		t.Fatalf("PublishTFRunEvent(%q, %q) error: %v", runID, status, err)
+	}
+}
+
+func streamMsgs(t *testing.T, js nats.JetStreamContext) uint64 {
+	t.Helper()
+	info, err := js.StreamInfo(RunEventsStreamName)
+	if err != nil {
+		t.Fatalf("could not read %s info: %v", RunEventsStreamName, err)
+	}
+	return info.State.Msgs
+}

--- a/pkg/runstream/stream.go
+++ b/pkg/runstream/stream.go
@@ -17,9 +17,13 @@ type Stream struct {
 	pollingKV  nats.KeyValue
 }
 
-func NewStream(js nats.JetStreamContext) StreamClient {
+// NewStream wires up the runstream JetStream client. dedupWindow is the
+// JetStream Duplicates window applied to the RUN_EVENTS stream so that
+// Nats-Msg-Id-based dedup actually fires server-side. Operators tune it via
+// TFBUDDY_JETSTREAM_DEDUP_WINDOW.
+func NewStream(js nats.JetStreamContext, dedupWindow time.Duration) StreamClient {
 
-	configureTFRunEventsStream(js)
+	configureTFRunEventsStream(js, dedupWindow)
 	configureTFRunPollingTaskStream(js)
 	kv, _ := configureTFRunMetadataKVStore(js)
 	pollingKV, _ := configureRunPollingKVStore(js)

--- a/pkg/runstream/stream_test.go
+++ b/pkg/runstream/stream_test.go
@@ -2,31 +2,40 @@ package runstream
 
 import (
 	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats-server/v2/server"
 	natstest "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 
-const TEST_PORT = 8369
+// testDedupWindow is the JetStream Duplicates window used by configureTFRunEventsStream
+// in tests. Pick a value that comfortably exceeds the duration of a single test.
+const testDedupWindow = 30 * time.Minute
 
-func RunServerOnPort(port int) *server.Server {
+// startTestNATS spins up an in-process NATS server bound to an OS-allocated
+// port (avoiding the flake risk of hard-coded ports when CI runs tests in
+// parallel or when local dev already has something on 8369). The server is
+// shut down via t.Cleanup so tests stay lean.
+func startTestNATS(t *testing.T) (*server.Server, string) {
+	t.Helper()
 	opts := natstest.DefaultTestOptions
-	opts.Port = port
+	opts.Port = -1 // ask the OS for a free port
 	opts.JetStream = true
-	return RunServerWithOptions(&opts)
-}
+	srv := natstest.RunServer(&opts)
+	t.Cleanup(srv.Shutdown)
 
-func RunServerWithOptions(opts *server.Options) *server.Server {
-	return natstest.RunServer(opts)
+	addr, ok := srv.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("NATS test server bound to unexpected addr type %T", srv.Addr())
+	}
+	return srv, fmt.Sprintf("nats://127.0.0.1:%d", addr.Port)
 }
 
 func Test_configureRunPollingKVStore(t *testing.T) {
-	s := RunServerOnPort(TEST_PORT)
-	defer s.Shutdown()
-
-	url := fmt.Sprintf("nats://127.0.0.1:%d", TEST_PORT)
+	_, url := startTestNATS(t)
 	nc := testConnect(t, url)
 	defer nc.Close()
 
@@ -60,17 +69,15 @@ func Test_configureRunPollingKVStore(t *testing.T) {
 }
 
 func Test_configureTFRunEventsStream(t *testing.T) {
-	s := RunServerOnPort(TEST_PORT)
-	defer s.Shutdown()
-
-	url := fmt.Sprintf("nats://127.0.0.1:%d", TEST_PORT)
+	_, url := startTestNATS(t)
 	nc := testConnect(t, url)
 	defer nc.Close()
 
 	js := testGetJetstreamContext(t, nc)
 
 	type args struct {
-		js nats.JetStreamContext
+		js          nats.JetStreamContext
+		dedupWindow time.Duration
 	}
 	tests := []struct {
 		name string
@@ -79,19 +86,21 @@ func Test_configureTFRunEventsStream(t *testing.T) {
 		{
 			"create",
 			args{
-				js: js,
+				js:          js,
+				dedupWindow: testDedupWindow,
 			},
 		},
 		{
 			"update",
 			args{
-				js: js,
+				js:          js,
+				dedupWindow: testDedupWindow,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configureTFRunEventsStream(tt.args.js)
+			configureTFRunEventsStream(tt.args.js, tt.args.dedupWindow)
 		})
 	}
 }

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -655,7 +655,9 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 	if t.GetAction() == ApplyAction {
 		isApply = true
 	} else if t.GetAction() != PlanAction {
-		return fmt.Errorf("run action was not apply or plan. %w", err)
+		// Unsupported action — retrying won't change it. Mark permanent so
+		// the worker ACKs and stops redelivering.
+		return fmt.Errorf("run action was not apply or plan. %w", utils.ErrPermanent)
 	}
 	// If the workspace is locked tell the user and don't queue a run
 	// Otherwise, TFC wil queue an apply, which might put them out of order
@@ -664,10 +666,17 @@ func (t *TFCTrigger) triggerRunForWorkspace(ctx context.Context, cfgWS *TFCWorks
 		if ws.Locked {
 			// Surface the tag-based locking MR too if we have one, so the user
 			// has something actionable to investigate alongside the TFC lock.
+			//
+			// Wrap with utils.ErrPermanent so the gitlab_hooks worker ACKs the
+			// note event instead of letting JetStream redeliver every 4s. The
+			// previous behavior (using a stale nil `err` in %w) both produced
+			// the "%!w(<nil>)" cosmetic glitch AND left the error retryable,
+			// which is what created the 30+ duplicate "locked workspace"
+			// comment storms observed on PEN-4703 (see MR !2224).
 			if lockingMR != "" {
-				return fmt.Errorf("refusing to Apply changes to a locked workspace (also tagged by MR %s). %w", lockingMR, err)
+				return fmt.Errorf("refusing to Apply changes to a locked workspace (also tagged by MR %s). %w", lockingMR, utils.ErrPermanent)
 			}
-			return fmt.Errorf("refusing to Apply changes to a locked workspace. %w", err)
+			return fmt.Errorf("refusing to Apply changes to a locked workspace. %w", utils.ErrPermanent)
 		} else if lockingMR != "" {
 			// Check if locking MR is already merged/closed (stale lock)
 			lockingMRIID, convErr := strconv.Atoi(lockingMR)

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -261,6 +261,76 @@ func TestTFCEvents_SingleWorkspaceApply(t *testing.T) {
 
 }
 
+// TestTFCEvents_ApplyToLockedWorkspaceIsPermanent guards the fix for the
+// !2224 / PEN-4703 storm: a `tfc apply` aimed at an already-locked workspace
+// must return a permanent error (so the gitlab_hooks worker ACKs the note
+// event instead of allowing JetStream redelivery) AND the error string must
+// be clean — no "%!w(<nil>)" cosmetic glitch left from wrapping a nil err.
+//
+// Pre-fix, the workspace-locked branch did `fmt.Errorf("…%w", err)` where
+// `err` was the stale (and nil) result from a successful GetWorkspaceByName.
+// That produced both the "%!w(<nil>)" suffix in the user-facing comment and
+// — combined with the retry path — multi-dozen duplicate "locked workspace"
+// comments on the same MR.
+func TestTFCEvents_ApplyToLockedWorkspaceIsPermanent(t *testing.T) {
+	ws := &tfc_trigger.ProjectConfig{
+		Workspaces: []*tfc_trigger.TFCWorkspace{{
+			Name:         "service-tfbuddy",
+			Organization: "zapier-test",
+			Mode:         "apply-before-merge",
+		}}}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	testSuite := mocks.CreateTestSuite(mockCtrl, mocks.TestOverrides{ProjectConfig: ws}, t)
+
+	// Override the default unlocked workspace from InitTestSuite with one
+	// that's already locked, so triggerRunForWorkspace hits the refusal path.
+	testSuite.MockApiClient.EXPECT().
+		GetWorkspaceByName(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&tfe.Workspace{ID: "service-tfbuddy", Locked: true}, nil).
+		AnyTimes()
+	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{}, nil)
+	// Critically: no CreateRunFromSource expectation — the locked path must
+	// not start a TFC run.
+
+	testSuite.InitTestSuite()
+
+	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
+		Action:                   tfc_trigger.ApplyAction,
+		Branch:                   "test-branch",
+		CommitSHA:                "abcd12233",
+		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
+		MergeRequestIID:          testSuite.MetaData.MRIID,
+		TriggerSource:            tfc_trigger.CommentTrigger,
+	})
+	trigger := tfc_trigger.NewTFCTrigger(config.C, testSuite.MockGitClient, testSuite.MockApiClient, testSuite.MockStreamClient, tCfg)
+	ctx, _ := otel.Tracer("FAKE").Start(context.Background(), "TEST")
+	triggeredWS, err := trigger.TriggerTFCEvents(ctx)
+	if err != nil {
+		t.Fatalf("TriggerTFCEvents returned unexpected top-level error: %v", err)
+	}
+	if triggeredWS == nil {
+		t.Fatal("expected TriggeredTFCWorkspaces, got nil")
+	}
+	if len(triggeredWS.Executed) != 0 {
+		t.Fatalf("expected no Executed workspaces (locked), got %v", triggeredWS.Executed)
+	}
+	if len(triggeredWS.Errored) != 1 {
+		t.Fatalf("expected exactly 1 Errored workspace, got %d", len(triggeredWS.Errored))
+	}
+	got := triggeredWS.Errored[0].Error
+	if !strings.Contains(got, "refusing to Apply changes to a locked workspace") {
+		t.Errorf("Errored message missing locked-workspace text: %q", got)
+	}
+	if !strings.Contains(got, "permanent error. cannot be retried") {
+		t.Errorf("Errored message missing permanent-error marker (would allow NATS redelivery): %q", got)
+	}
+	if strings.Contains(got, "%!w(<nil>)") || strings.Contains(got, "%!w") {
+		t.Errorf("Errored message still contains %%w formatting glitch: %q", got)
+	}
+}
+
 func TestTFCEvents_MultiWorkspaceApply(t *testing.T) {
 
 	ws := &tfc_trigger.ProjectConfig{

--- a/pkg/tfc_trigger/workspace_stream.go
+++ b/pkg/tfc_trigger/workspace_stream.go
@@ -86,7 +86,12 @@ type WorkspaceStream struct {
 	stream *gongs.GenericStream[WorkspaceTriggerMsg, *WorkspaceTriggerMsg]
 }
 
-func NewWorkspaceStream(js nats.JetStreamContext, workspaceStreamReplicas int) (*WorkspaceStream, error) {
+// NewWorkspaceStream provisions the per-workspace fan-out stream. dedupWindow
+// sets the JetStream Duplicates window used in tandem with the Nats-Msg-Id
+// stamped by gongs from WorkspaceTriggerMsg.GetId — without Duplicates set,
+// the per-delivery dedup is silently inert at the server. Operators tune the
+// window via TFBUDDY_JETSTREAM_DEDUP_WINDOW.
+func NewWorkspaceStream(js nats.JetStreamContext, workspaceStreamReplicas int, dedupWindow time.Duration) (*WorkspaceStream, error) {
 	cfg := &nats.StreamConfig{
 		Name:        WorkspaceTriggerStreamName,
 		Description: "Fan-out queue: one message per workspace dispatched by an MR/PR trigger",
@@ -95,6 +100,7 @@ func NewWorkspaceStream(js nats.JetStreamContext, workspaceStreamReplicas int) (
 		MaxMsgs:     workspaceStreamMaxMsgs,
 		MaxAge:      workspaceStreamMaxAge,
 		Replicas:    workspaceStreamReplicas,
+		Duplicates:  dedupWindow,
 	}
 
 	info, err := js.StreamInfo(cfg.Name)


### PR DESCRIPTION
## Summary

Two fixes for duplicate-comment storms tfbuddy posts on a single MR/PR discussion thread during an otherwise normal run lifecycle. Both reproduced on `zapier/terraform-services` today (PEN-4703).

## Bug 1 — duplicate `Status:` replies per TFC notification webhook

**Symptom.** On an auto-apply run, the MR ended up with 6× `Status: planning. Auto Apply Enabled…` replies plus 3× `Status: applied. Imports: …` replies inside a single tfbuddy discussion thread — for a *single* TFC run that had 10 run-events on the TFC side.

**Root cause.** `pkg/runstream/run_event.go` `PublishTFRunEvent` published one `TFRunEvent` per incoming TFC notification webhook with no idempotency. TFC fires one webhook per configured notification trigger, and several triggers resolve to the same `RunStatus` over the lifetime of a run (`plan_queued`, `planning`, `cost_estimating`, `policy_checking` can all surface as `planning` in the notification payload). Each redundant webhook spawned a new GitLab reply via `AddMergeRequestDiscussionReply`, which is pure-create, never update. The polling sibling in `pkg/tfc_hooks/polling.go` already had a `task.GetLastStatus()` gate; the webhook path did not.

**Fix.** Stamp every publish with `nats.MsgId(runID + ":" + newStatus)` and add `Duplicates: 30 * time.Minute` to the stream config. JetStream collapses redundant publishes server-side. PR #62 already deduped the workspace-trigger stream via `DeliveryID`; this brings the run-event stream up to parity.

## Bug 2 — locked-workspace error storm and `%!w(<nil>)` glitch

**Symptom.** Applying to a workspace that was already locked produced `:no_entry: services-…-production-… could not be run because: refusing to Apply changes to a locked workspace. %!w(<nil>)` on the MR — and during one incident the same comment landed 30+ times at ~4s intervals while tfbuddy also kicked off 8 redundant successful applies on the same workspace.

**Root cause.** In `pkg/tfc_trigger/tfc_trigger.go`, three return sites wrapped the local `err` variable into a `%w` verb even though `err` was nil at that point (it was the stale, successful-and-nil return from the earlier `GetWorkspaceByName`). That produced the `%!w(<nil>)` cosmetic artifact and — because the resulting error was not marked with `utils.ErrPermanent` — left it eligible for JetStream redelivery if it ever propagated to a worker.

**Fix.** Replace the nil `err` with `utils.ErrPermanent` in the three offending `%w` wraps. `err.Error()` is now clean *and* `errors.Is(err, utils.ErrPermanent) == true`, so the existing `utils.EmitPermanentError` chain in `pkg/gitlab_hooks/hook_worker.go:60` will ACK the NATS message instead of letting it redeliver.