### PR TITLE
fix: block merge on workspace block

### DIFF
--- a/pkg/mocks/mock_vcs.go
+++ b/pkg/mocks/mock_vcs.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source interfaces.go -destination=../mocks/mock_vcs.go -package=mocks github.com/zapier/tfbuddy/pkg/vcs
 //
+
 // Package mocks is a generated GoMock package.
 package mocks
 
@@ -20,6 +21,7 @@ import (
 type MockGitClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockGitClientMockRecorder
+	isgomock struct{}
 }
 
 // MockGitClientMockRecorder is the mock recorder for MockGitClient.
@@ -144,7 +146,7 @@ func (mr *MockGitClientMockRecorder) GetMergeRequestModifiedFiles(ctx, mrIID, pr
 }
 
 // GetOldRunUrls mocks base method.
-func (m *MockGitClient) GetOldRunUrls(ctx context.Context, mrIID int, project string, rootCommentID int, workspace string, action string) (string, error) {
+func (m *MockGitClient) GetOldRunUrls(ctx context.Context, mrIID int, project string, rootCommentID int, workspace, action string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOldRunUrls", ctx, mrIID, project, rootCommentID, workspace, action)
 	ret0, _ := ret[0].(string)
@@ -231,6 +233,20 @@ func (mr *MockGitClientMockRecorder) SetCommitStatus(ctx, projectWithNS, commitS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCommitStatus", reflect.TypeOf((*MockGitClient)(nil).SetCommitStatus), ctx, projectWithNS, commitSHA, status)
 }
 
+// SetMergeRequestStatus mocks base method.
+func (m *MockGitClient) SetMergeRequestStatus(ctx context.Context, projectWithNS, commitSHA, name, state, description, targetURL string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMergeRequestStatus", ctx, projectWithNS, commitSHA, name, state, description, targetURL)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMergeRequestStatus indicates an expected call of SetMergeRequestStatus.
+func (mr *MockGitClientMockRecorder) SetMergeRequestStatus(ctx, projectWithNS, commitSHA, name, state, description, targetURL any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMergeRequestStatus", reflect.TypeOf((*MockGitClient)(nil).SetMergeRequestStatus), ctx, projectWithNS, commitSHA, name, state, description, targetURL)
+}
+
 // UpdateMergeRequestDiscussionNote mocks base method.
 func (m *MockGitClient) UpdateMergeRequestDiscussionNote(ctx context.Context, mrIID, noteID int, project, discussionID, comment string) (vcs.MRNote, error) {
 	m.ctrl.T.Helper()
@@ -250,6 +266,7 @@ func (mr *MockGitClientMockRecorder) UpdateMergeRequestDiscussionNote(ctx, mrIID
 type MockGitRepo struct {
 	ctrl     *gomock.Controller
 	recorder *MockGitRepoMockRecorder
+	isgomock struct{}
 }
 
 // MockGitRepoMockRecorder is the mock recorder for MockGitRepo.
@@ -331,6 +348,7 @@ func (mr *MockGitRepoMockRecorder) GetModifiedFileNamesBetweenCommits(oldest, ne
 type MockMRApproved struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRApprovedMockRecorder
+	isgomock struct{}
 }
 
 // MockMRApprovedMockRecorder is the mock recorder for MockMRApproved.
@@ -368,6 +386,7 @@ func (mr *MockMRApprovedMockRecorder) IsApproved() *gomock.Call {
 type MockMRDiscussion struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRDiscussionMockRecorder
+	isgomock struct{}
 }
 
 // MockMRDiscussionMockRecorder is the mock recorder for MockMRDiscussion.
@@ -405,6 +424,7 @@ func (mr *MockMRDiscussionMockRecorder) GetDiscussionID() *gomock.Call {
 type MockMRDiscussionNotes struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRDiscussionNotesMockRecorder
+	isgomock struct{}
 }
 
 // MockMRDiscussionNotesMockRecorder is the mock recorder for MockMRDiscussionNotes.
@@ -456,6 +476,7 @@ func (mr *MockMRDiscussionNotesMockRecorder) GetMRNotes() *gomock.Call {
 type MockMRNote struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRNoteMockRecorder
+	isgomock struct{}
 }
 
 // MockMRNoteMockRecorder is the mock recorder for MockMRNote.
@@ -493,6 +514,7 @@ func (mr *MockMRNoteMockRecorder) GetNoteID() *gomock.Call {
 type MockDetailedMR struct {
 	ctrl     *gomock.Controller
 	recorder *MockDetailedMRMockRecorder
+	isgomock struct{}
 }
 
 // MockDetailedMRMockRecorder is the mock recorder for MockDetailedMR.
@@ -526,20 +548,6 @@ func (mr *MockDetailedMRMockRecorder) GetAuthor() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthor", reflect.TypeOf((*MockDetailedMR)(nil).GetAuthor))
 }
 
-// GetState mocks base method.
-func (m *MockDetailedMR) GetState() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetState")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetState indicates an expected call of GetState.
-func (mr *MockDetailedMRMockRecorder) GetState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockDetailedMR)(nil).GetState))
-}
-
 // GetInternalID mocks base method.
 func (m *MockDetailedMR) GetInternalID() int {
 	m.ctrl.T.Helper()
@@ -566,6 +574,20 @@ func (m *MockDetailedMR) GetSourceBranch() string {
 func (mr *MockDetailedMRMockRecorder) GetSourceBranch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSourceBranch", reflect.TypeOf((*MockDetailedMR)(nil).GetSourceBranch))
+}
+
+// GetState mocks base method.
+func (m *MockDetailedMR) GetState() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetState")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetState indicates an expected call of GetState.
+func (mr *MockDetailedMRMockRecorder) GetState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockDetailedMR)(nil).GetState))
 }
 
 // GetTargetBranch mocks base method.
@@ -628,6 +650,7 @@ func (mr *MockDetailedMRMockRecorder) HasConflicts() *gomock.Call {
 type MockMR struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRMockRecorder
+	isgomock struct{}
 }
 
 // MockMRMockRecorder is the mock recorder for MockMR.
@@ -707,6 +730,7 @@ func (mr *MockMRMockRecorder) GetTargetBranch() *gomock.Call {
 type MockMRBranches struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRBranchesMockRecorder
+	isgomock struct{}
 }
 
 // MockMRBranchesMockRecorder is the mock recorder for MockMRBranches.
@@ -758,6 +782,7 @@ func (mr *MockMRBranchesMockRecorder) GetTargetBranch() *gomock.Call {
 type MockMRAuthor struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRAuthorMockRecorder
+	isgomock struct{}
 }
 
 // MockMRAuthorMockRecorder is the mock recorder for MockMRAuthor.
@@ -795,6 +820,7 @@ func (mr *MockMRAuthorMockRecorder) GetUsername() *gomock.Call {
 type MockCommitStatusOptions struct {
 	ctrl     *gomock.Controller
 	recorder *MockCommitStatusOptionsMockRecorder
+	isgomock struct{}
 }
 
 // MockCommitStatusOptionsMockRecorder is the mock recorder for MockCommitStatusOptions.
@@ -902,6 +928,7 @@ func (mr *MockCommitStatusOptionsMockRecorder) GetTargetURL() *gomock.Call {
 type MockCommitStatus struct {
 	ctrl     *gomock.Controller
 	recorder *MockCommitStatusMockRecorder
+	isgomock struct{}
 }
 
 // MockCommitStatusMockRecorder is the mock recorder for MockCommitStatus.
@@ -939,6 +966,7 @@ func (mr *MockCommitStatusMockRecorder) Info() *gomock.Call {
 type MockProjectPipeline struct {
 	ctrl     *gomock.Controller
 	recorder *MockProjectPipelineMockRecorder
+	isgomock struct{}
 }
 
 // MockProjectPipelineMockRecorder is the mock recorder for MockProjectPipeline.
@@ -990,6 +1018,7 @@ func (mr *MockProjectPipelineMockRecorder) GetSource() *gomock.Call {
 type MockProject struct {
 	ctrl     *gomock.Controller
 	recorder *MockProjectMockRecorder
+	isgomock struct{}
 }
 
 // MockProjectMockRecorder is the mock recorder for MockProject.
@@ -1027,6 +1056,7 @@ func (mr *MockProjectMockRecorder) GetPathWithNamespace() *gomock.Call {
 type MockMRCommentEvent struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRCommentEventMockRecorder
+	isgomock struct{}
 }
 
 // MockMRCommentEventMockRecorder is the mock recorder for MockMRCommentEvent.
@@ -1106,6 +1136,7 @@ func (mr *MockMRCommentEventMockRecorder) GetProject() *gomock.Call {
 type MockMRAttributes struct {
 	ctrl     *gomock.Controller
 	recorder *MockMRAttributesMockRecorder
+	isgomock struct{}
 }
 
 // MockMRAttributesMockRecorder is the mock recorder for MockMRAttributes.
@@ -1171,6 +1202,7 @@ func (mr *MockMRAttributesMockRecorder) GetType() *gomock.Call {
 type MockCommit struct {
 	ctrl     *gomock.Controller
 	recorder *MockCommitMockRecorder
+	isgomock struct{}
 }
 
 // MockCommitMockRecorder is the mock recorder for MockCommit.

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -462,6 +462,21 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 // Returning an error puts the workspace into status.Errored verbatim.
 type workspaceDispatchFn func(ctx context.Context, ws *TFCWorkspace) error
 
+// publishBlockedStatus publishes failing commit statuses for both plan and
+// apply of a blocked workspace so GitLab's required-status check gates the
+// merge. Without this the workspace has no commit status at all and GitLab
+// allows the merge despite the ⛔ MR comment. Logged-only on failure: the
+// MR comment already informs the user.
+func (t *TFCTrigger) publishBlockedStatus(ctx context.Context, workspace string) {
+	const description = "Blocked: target branch modified workspace paths since divergence."
+	for _, action := range []string{"plan", "apply"} {
+		name := fmt.Sprintf("TFC/%s/%s", action, workspace)
+		if err := t.gl.SetMergeRequestStatus(ctx, t.GetProjectNameWithNamespace(), t.GetCommitSHA(), name, "failed", description, ""); err != nil {
+			log.Error().Err(err).Str("ws", workspace).Str("action", action).Msg("could not publish blocked commit status")
+		}
+	}
+}
+
 func (t *TFCTrigger) dispatchWorkspaces(ctx context.Context, workspaces []*TFCWorkspace, blocked map[string]struct{}, dispatch workspaceDispatchFn) *TriggeredTFCWorkspaces {
 	status := &TriggeredTFCWorkspaces{
 		Errored:  make([]*ErroredWorkspace, 0),
@@ -483,6 +498,7 @@ func (t *TFCTrigger) dispatchWorkspaces(ctx context.Context, workspaces []*TFCWo
 				Name:  ws.Name,
 				Error: fmt.Sprintf("Blocked: workspace-relevant paths (dir: '%s', triggerDirs: %v) have been modified on the target branch since this branch diverged. Please rebase/merge the target branch to resolve this.", ws.Dir, ws.TriggerDirs),
 			})
+			t.publishBlockedStatus(ctx, ws.Name)
 			continue
 		}
 		if err := dispatch(ctx, ws); err != nil {

--- a/pkg/tfc_trigger/tfc_trigger.go
+++ b/pkg/tfc_trigger/tfc_trigger.go
@@ -462,11 +462,9 @@ func (t *TFCTrigger) TriggerTFCEvents(ctx context.Context) (*TriggeredTFCWorkspa
 // Returning an error puts the workspace into status.Errored verbatim.
 type workspaceDispatchFn func(ctx context.Context, ws *TFCWorkspace) error
 
-// publishBlockedStatus publishes failing commit statuses for both plan and
-// apply of a blocked workspace so GitLab's required-status check gates the
-// merge. Without this the workspace has no commit status at all and GitLab
-// allows the merge despite the ⛔ MR comment. Logged-only on failure: the
-// MR comment already informs the user.
+// publishBlockedStatus sets TFC/plan and TFC/apply to failed so the merge gate
+// fires for a blocked workspace. Both are set to match the existing convention
+// where a pending plan pre-emptively marks apply as failed.
 func (t *TFCTrigger) publishBlockedStatus(ctx context.Context, workspace string) {
 	const description = "Blocked: target branch modified workspace paths since divergence."
 	for _, action := range []string{"plan", "apply"} {

--- a/pkg/tfc_trigger/tfc_trigger_test.go
+++ b/pkg/tfc_trigger/tfc_trigger_test.go
@@ -544,6 +544,18 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 	testSuite.MockGitRepo.EXPECT().GetModifiedFileNamesBetweenCommits(testSuite.MetaData.CommonSHA, "main").Return([]string{"terraform.tf"}, nil)
 	testSuite.MockGitClient.EXPECT().GetMergeRequestModifiedFiles(gomock.Any(), testSuite.MetaData.MRIID, testSuite.MetaData.ProjectNameNS).Return([]string{"main.tf"}, nil)
 
+	// Blocked workspaces must publish a failing commit status for both plan
+	// and apply so GitLab's required-status check actually gates the merge.
+	commitSHA := "abcd12233"
+	testSuite.MockGitClient.EXPECT().SetMergeRequestStatus(
+		gomock.Any(), testSuite.MetaData.ProjectNameNS, commitSHA,
+		fmt.Sprintf("TFC/plan/%s", mocks.TF_WORKSPACE_NAME), "failed", gomock.Any(), "",
+	).Return(nil)
+	testSuite.MockGitClient.EXPECT().SetMergeRequestStatus(
+		gomock.Any(), testSuite.MetaData.ProjectNameNS, commitSHA,
+		fmt.Sprintf("TFC/apply/%s", mocks.TF_WORKSPACE_NAME), "failed", gomock.Any(), "",
+	).Return(nil)
+
 	mockStreamClient := mocks.NewMockStreamClient(mockCtrl)
 
 	testSuite.InitTestSuite()
@@ -554,7 +566,7 @@ func TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches(t *testing.T) {
 	tCfg, _ := tfc_trigger.NewTFCTriggerConfig(&tfc_trigger.TFCTriggerOptions{
 		Action:                   tfc_trigger.ApplyAction,
 		Branch:                   testSuite.MetaData.SourceBranch,
-		CommitSHA:                "abcd12233",
+		CommitSHA:                commitSHA,
 		ProjectNameWithNamespace: testSuite.MetaData.ProjectNameNS,
 		MergeRequestIID:          testSuite.MetaData.MRIID,
 		TriggerSource:            tfc_trigger.CommentTrigger,

--- a/pkg/vcs/github/client.go
+++ b/pkg/vcs/github/client.go
@@ -349,6 +349,11 @@ func (c *Client) SetCommitStatus(ctx context.Context, projectWithNS string, comm
 	return nil, nil
 }
 
+func (c *Client) SetMergeRequestStatus(ctx context.Context, projectWithNS, commitSHA, name, state, description, targetURL string) error {
+	//TODO implement me
+	return nil
+}
+
 func (c *Client) GetPipelinesForCommit(ctx context.Context, projectWithNS string, commitSHA string) ([]vcs.ProjectPipeline, error) {
 	//TODO implement me
 	return nil, nil

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -111,11 +111,9 @@ func (c *GitlabClient) SetCommitStatus(ctx context.Context, projectWithNS string
 	}, createBackOffWithRetries())
 }
 
-// SetMergeRequestStatus publishes a single commit status without requiring a
-// TFC run. Used to mark blocked workspaces as failed so GitLab's required
-// status check still gates the merge. Unlike updateStatus in mr_status_updater
-// this does not attach a pipeline ID — a commit-level status is enough to
-// gate the merge and avoids a 30s pipeline-lookup backoff for the block path.
+// SetMergeRequestStatus publishes a commit status without attaching a pipeline
+// ID. Commit-level status is enough to gate the merge and skips the 30s
+// pipeline-lookup backoff used by run-status updates.
 func (c *GitlabClient) SetMergeRequestStatus(ctx context.Context, projectWithNS, commitSHA, name, state, description, targetURL string) error {
 	_, span := otel.Tracer("TFC").Start(ctx, "SetMergeRequestStatus")
 	defer span.End()

--- a/pkg/vcs/gitlab/client.go
+++ b/pkg/vcs/gitlab/client.go
@@ -111,6 +111,30 @@ func (c *GitlabClient) SetCommitStatus(ctx context.Context, projectWithNS string
 	}, createBackOffWithRetries())
 }
 
+// SetMergeRequestStatus publishes a single commit status without requiring a
+// TFC run. Used to mark blocked workspaces as failed so GitLab's required
+// status check still gates the merge. Unlike updateStatus in mr_status_updater
+// this does not attach a pipeline ID — a commit-level status is enough to
+// gate the merge and avoids a 30s pipeline-lookup backoff for the block path.
+func (c *GitlabClient) SetMergeRequestStatus(ctx context.Context, projectWithNS, commitSHA, name, state, description, targetURL string) error {
+	_, span := otel.Tracer("TFC").Start(ctx, "SetMergeRequestStatus")
+	defer span.End()
+
+	opts := &gogitlab.SetCommitStatusOptions{
+		Name:    ptr(name),
+		Context: ptr(name),
+		State:   gogitlab.BuildStateValue(state),
+	}
+	if description != "" {
+		opts.Description = ptr(description)
+	}
+	if targetURL != "" {
+		opts.TargetURL = ptr(targetURL)
+	}
+	_, err := c.SetCommitStatus(ctx, projectWithNS, commitSHA, &GitlabCommitStatusOptions{opts})
+	return err
+}
+
 func (c *GitlabClient) GetCommitStatuses(ctx context.Context, projectID, commitSHA string) []*gogitlab.CommitStatus {
 	_, span := otel.Tracer("TFC").Start(ctx, "GetCommitStatuses")
 	defer span.End()

--- a/pkg/vcs/interfaces.go
+++ b/pkg/vcs/interfaces.go
@@ -16,6 +16,11 @@ type GitClient interface {
 	ResolveMergeRequestDiscussion(context.Context, string, int, string) error
 	AddMergeRequestDiscussionReply(ctx context.Context, mrIID int, project, discussionID, comment string) (MRNote, error)
 	SetCommitStatus(ctx context.Context, projectWithNS string, commitSHA string, status CommitStatusOptions) (CommitStatus, error)
+	// SetMergeRequestStatus publishes a single named commit status for an MR
+	// without requiring a TFC run to exist. Used to mark workspaces as failed
+	// when tfbuddy decides not to run them (e.g., blocked by target-branch
+	// divergence) so GitLab's required-status check still gates the merge.
+	SetMergeRequestStatus(ctx context.Context, projectWithNS string, commitSHA string, name string, state string, description string, targetURL string) error
 	GetPipelinesForCommit(ctx context.Context, projectWithNS string, commitSHA string) ([]ProjectPipeline, error)
 	GetOldRunUrls(ctx context.Context, mrIID int, project string, rootCommentID int, workspace string, action string) (string, error)
 	MergeMR(ctx context.Context, mrIID int, project string) error

--- a/pkg/vcs/interfaces.go
+++ b/pkg/vcs/interfaces.go
@@ -16,10 +16,8 @@ type GitClient interface {
 	ResolveMergeRequestDiscussion(context.Context, string, int, string) error
 	AddMergeRequestDiscussionReply(ctx context.Context, mrIID int, project, discussionID, comment string) (MRNote, error)
 	SetCommitStatus(ctx context.Context, projectWithNS string, commitSHA string, status CommitStatusOptions) (CommitStatus, error)
-	// SetMergeRequestStatus publishes a single named commit status for an MR
-	// without requiring a TFC run to exist. Used to mark workspaces as failed
-	// when tfbuddy decides not to run them (e.g., blocked by target-branch
-	// divergence) so GitLab's required-status check still gates the merge.
+	// SetMergeRequestStatus publishes a commit status without a TFC run, used
+	// to gate the merge when tfbuddy refuses to run a workspace.
 	SetMergeRequestStatus(ctx context.Context, projectWithNS string, commitSHA string, name string, state string, description string, targetURL string) error
 	GetPipelinesForCommit(ctx context.Context, projectWithNS string, commitSHA string) ([]ProjectPipeline, error)
 	GetOldRunUrls(ctx context.Context, mrIID int, project string, rootCommentID int, workspace string, action string) (string, error)


### PR DESCRIPTION
## Summary

When tfbuddy detects that a workspace's relevant paths were modified on the
target branch since the source branch diverged, it refuses to start a TFC run
for that workspace and posts a `:no_entry:` MR comment. However, **it never
publishes a failing GitLab commit status**, so GitLab's required-status check
has nothing to fail on and the MR can still be merged.

This change publishes failing commit statuses for `TFC/plan/<ws>` and
`TFC/apply/<ws>` (both, to match the pre-emptive pattern in
`mr_status_updater.go`) so the merge gate fires.

## Changes

- `pkg/vcs/interfaces.go` — add `SetMergeRequestStatus(ctx, project, sha, name, state, description, targetURL) error` to `GitClient`. Primitive args keep the trigger code VCS-agnostic.
- `pkg/vcs/gitlab/client.go` — implements the method: builds `gogitlab.SetCommitStatusOptions` and delegates to existing `SetCommitStatus`. Skips the 30s pipeline-lookup backoff used by run-status updates; a commit-level status is sufficient to gate the merge for blocked workspaces.
- `pkg/vcs/github/client.go` — `nil` stub consistent with the existing `SetCommitStatus` TODO.
- `pkg/tfc_trigger/tfc_trigger.go` — `dispatchWorkspaces` now calls `publishBlockedStatus(ctx, ws.Name)` on the blocked branch, which sets `TFC/plan/<ws>=failed` and `TFC/apply/<ws>=failed`. Both are set so the merge gate fires regardless of which is the required status.
- `pkg/mocks/mock_vcs.go` — regenerated via `go generate ./pkg/vcs/...`.
- `pkg/tfc_trigger/tfc_trigger_test.go` — `TestTFCEvents_WorkspaceApplyModifiedBothSrcDstBranches` now asserts both `SetMergeRequestStatus` calls.

## Rebase behavior

No explicit cleanup needed. A new commit means a new SHA; tfbuddy re-evaluates
on the push webhook:
- Still blocked → publishes new failed statuses on the new SHA.
- No longer blocked → the normal TFC run path replaces them via the existing pipeline (`mr_status_updater.go`).